### PR TITLE
Add CVEChecker which guesses the pkg name and version of an archive

### DIFF
--- a/src/checker.py
+++ b/src/checker.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2018 Endless Mobile, Inc.
 #
 # Authors:
-#       Andrew Hayzen <ahayzen@gmail.com>
 #       Joaquim Rocha <jrocha@endlessm.com>
 #
 # This program is free software; you can redistribute it and/or modify
@@ -90,8 +89,8 @@ class ManifestChecker:
                 size = source.get('size', -1)
                 checker_data = source.get('x-checker-data')
 
-                ext_data = ExternalData(data_type, name, url, sha256sum, size, arches,
-                                        checker_data)
+                ext_data = ExternalData(data_type, name, url, sha256sum, size,
+                                        arches, checker_data)
                 external_data.append(ext_data)
 
         return external_data

--- a/src/checker.py
+++ b/src/checker.py
@@ -69,10 +69,6 @@ class ManifestChecker:
     def _get_module_data_from_json(self, json_data):
         external_data = []
         for module in json_data.get('modules', []):
-            # This is a guess at the package name from the name the author
-            # has given to the module block
-            pkg_name = module.get('name', None)
-
             for source in module.get('sources', []):
                 url = source.get('url', None)
                 if not url:
@@ -94,8 +90,8 @@ class ManifestChecker:
                 size = source.get('size', -1)
                 checker_data = source.get('x-checker-data')
 
-                ext_data = ExternalData(data_type, pkg_name, name, url,
-                                        sha256sum, size, arches, checker_data)
+                ext_data = ExternalData(data_type, name, url, sha256sum, size, arches,
+                                        checker_data)
                 external_data.append(ext_data)
 
         return external_data

--- a/src/checker.py
+++ b/src/checker.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2018 Endless Mobile, Inc.
 #
 # Authors:
+#       Andrew Hayzen <ahayzen@gmail.com>
 #       Joaquim Rocha <jrocha@endlessm.com>
 #
 # This program is free software; you can redistribute it and/or modify
@@ -68,6 +69,10 @@ class ManifestChecker:
     def _get_module_data_from_json(self, json_data):
         external_data = []
         for module in json_data.get('modules', []):
+            # This is a guess at the package name from the name the author
+            # has given to the module block
+            pkg_name = module.get('name', None)
+
             for source in module.get('sources', []):
                 url = source.get('url', None)
                 if not url:
@@ -89,8 +94,8 @@ class ManifestChecker:
                 size = source.get('size', -1)
                 checker_data = source.get('x-checker-data')
 
-                ext_data = ExternalData(data_type, name, url, sha256sum, size,
-                                        arches, checker_data)
+                ext_data = ExternalData(data_type, pkg_name, name, url,
+                                        sha256sum, size, arches, checker_data)
                 external_data.append(ext_data)
 
         return external_data

--- a/src/checkers/cvechecker.py
+++ b/src/checkers/cvechecker.py
@@ -28,12 +28,23 @@ from lib.externaldata import ExternalData, CheckerRegistry, Checker
 class CVEChecker(Checker):
 
     def check(self, external_data):
+        # TODO: if checker_data or package-name are None
+        # attempt to guess package name from url if archive
+
+        if external_data.checker_data is None:
+            external_data.state = ExternalData.State.BROKEN
+            return
+
+        pkg_name = external_data.checker_data.get("package-name", None)
+
+        if pkg_name is None:
+            logging.debug('CVEChecker: No package-name given')
+            external_data.state = ExternalData.State.BROKEN
+            return
+
         try:
-            version = CVEChecker.extract_version_from_url(
-                external_data.url, external_data.type,
-            )
-            logging.debug('CVEChecker: Found %s of the version %s' %
-                          (external_data.pkg_name, version))
+            version = CVEChecker.extract_version_from_url(external_data.url, external_data.type)
+            logging.debug('CVEChecker: Found {} of the version {}'.format(pkg_name, version))
         except ValueError:
             external_data.state = ExternalData.State.BROKEN
         else:
@@ -54,7 +65,7 @@ class CVEChecker(Checker):
                 logging.debug('CVEChecker: Version not found in {}'.format(url))
                 raise ValueError
         else:
-            logging.debug('CVEChecker: Unknown type %s' % data_type)
+            logging.debug('CVEChecker: Unknown type {}'.format(data_type))
             raise ValueError
 
 

--- a/src/checkers/cvechecker.py
+++ b/src/checkers/cvechecker.py
@@ -48,6 +48,8 @@ class CVEChecker(Checker):
         except ValueError:
             external_data.state = ExternalData.State.BROKEN
         else:
+            # TODO: we should probably provide the pkg_name as a hint here?
+            external_data.current_version = version
             external_data.state = ExternalData.State.VALID
 
         # TODO: need similar to new_version but for cve_vuln

--- a/src/checkers/cvechecker.py
+++ b/src/checkers/cvechecker.py
@@ -1,0 +1,61 @@
+# Copyright (C) 2018 Endless Mobile, Inc.
+#
+# Authors:
+#       Andrew Hayzen <ahayzen@gmail.com>
+#       Joaquim Rocha <jrocha@endlessm.com>
+#       Patrick Griffis <tingping@tingping.se>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+import logging
+import re
+
+from lib.externaldata import ExternalData, CheckerRegistry, Checker
+
+
+class CVEChecker(Checker):
+
+    def check(self, external_data):
+        try:
+            version = CVEChecker.extract_version_from_url(
+                external_data.url, external_data.type,
+            )
+            logging.debug('CVEChecker: Found %s of the version %s' %
+                          (external_data.pkg_name, version))
+        except ValueError:
+            external_data.state = ExternalData.State.BROKEN
+        else:
+            external_data.state = ExternalData.State.VALID
+
+        # TODO: need similar to new_version but for cve_vuln
+        # this should also output to JSON
+
+    @staticmethod
+    def extract_version_from_url(url, data_type):
+        if data_type == ExternalData.Type.ARCHIVE:
+            filename = url.rpartition('/')[2]
+            match = re.search(r'(\d+\.\d+(?:\.\d+)?)', filename)
+
+            if match:
+                return match.groups()[-1]
+            else:
+                logging.debug('CVEChecker: Version not found in {}'.format(url))
+                raise ValueError
+        else:
+            logging.debug('CVEChecker: Unknown type %s' % data_type)
+            raise ValueError
+
+
+CheckerRegistry.register_checker(CVEChecker)

--- a/src/lib/externaldata.py
+++ b/src/lib/externaldata.py
@@ -49,6 +49,7 @@ class ExternalData:
         self.arches = arches
         self.type = data_type
         self.checker_data = checker_data
+        self.current_version = None
         self.new_version = None
         self.state = ExternalData.State.UNKNOWN
 

--- a/src/lib/externaldata.py
+++ b/src/lib/externaldata.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2018 Endless Mobile, Inc.
 #
 # Authors:
-#       Andrew Hayzen <ahayzen@gmail.com>
 #       Joaquim Rocha <jrocha@endlessm.com>
 #
 # This program is free software; you can redistribute it and/or modify
@@ -41,8 +40,8 @@ class ExternalData:
         VALID = 1 << 1 # URL is reachable
         BROKEN = 1 << 2 # URL couldn't be reached
 
-    def __init__(self, data_type, filename, url, checksum, size=-1,
-                 arches=[], checker_data=None):
+    def __init__(self, data_type, filename, url, checksum, size=-1, arches=[],
+                 checker_data=None):
         self.filename = filename
         self.url = url
         self.checksum = checksum
@@ -62,7 +61,6 @@ class ExternalData:
                '  Size:    {size}\n' \
                '  Arches:  {arches}\n' \
                '  Checker: {checker_data}'.format(state=self.state.name,
-                                                  pkg_name=self.pkg_name,
                                                   filename=self.filename,
                                                   type=self.type.name,
                                                   url=self.url,

--- a/src/lib/externaldata.py
+++ b/src/lib/externaldata.py
@@ -41,9 +41,8 @@ class ExternalData:
         VALID = 1 << 1 # URL is reachable
         BROKEN = 1 << 2 # URL couldn't be reached
 
-    def __init__(self, data_type, pkg_name, filename, url, checksum, size=-1,
+    def __init__(self, data_type, filename, url, checksum, size=-1,
                  arches=[], checker_data=None):
-        self.pkg_name = pkg_name
         self.filename = filename
         self.url = url
         self.checksum = checksum
@@ -56,7 +55,6 @@ class ExternalData:
 
     def __str__(self):
         info = '{filename}:\n' \
-               '  PkgName: {pkg_name}\n' \
                '  State:   {state}\n' \
                '  Type:    {type}\n' \
                '  URL:     {url}\n' \

--- a/src/lib/externaldata.py
+++ b/src/lib/externaldata.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2018 Endless Mobile, Inc.
 #
 # Authors:
+#       Andrew Hayzen <ahayzen@gmail.com>
 #       Joaquim Rocha <jrocha@endlessm.com>
 #
 # This program is free software; you can redistribute it and/or modify
@@ -40,8 +41,9 @@ class ExternalData:
         VALID = 1 << 1 # URL is reachable
         BROKEN = 1 << 2 # URL couldn't be reached
 
-    def __init__(self, data_type, filename, url, checksum, size=-1, arches=[],
-                 checker_data=None):
+    def __init__(self, data_type, pkg_name, filename, url, checksum, size=-1,
+                 arches=[], checker_data=None):
+        self.pkg_name = pkg_name
         self.filename = filename
         self.url = url
         self.checksum = checksum
@@ -54,6 +56,7 @@ class ExternalData:
 
     def __str__(self):
         info = '{filename}:\n' \
+               '  PkgName: {pkg_name}\n' \
                '  State:   {state}\n' \
                '  Type:    {type}\n' \
                '  URL:     {url}\n' \
@@ -61,6 +64,7 @@ class ExternalData:
                '  Size:    {size}\n' \
                '  Arches:  {arches}\n' \
                '  Checker: {checker_data}'.format(state=self.state.name,
+                                                  pkg_name=self.pkg_name,
                                                   filename=self.filename,
                                                   type=self.type.name,
                                                   url=self.url,

--- a/tests/org.cvechecker.Manifest.json
+++ b/tests/org.cvechecker.Manifest.json
@@ -1,0 +1,31 @@
+{
+    "app-id": "org.cvechecker.Checker",
+    "branch": "stable",
+    "runtime": "org.freedesktop.Platform",
+    "runtime-version": "1.6",
+    "sdk": "org.freedesktop.Sdk",
+    "command": "checker",
+    "finish-args": [
+    ],
+    "modules": [
+        {
+            "name": "phony",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://some-gibberish-phony-url.phony/releases/pkga-1.2.3.tar.bz2",
+                    "sha256": "000000000000000000000000000000000000000000000000000000000000000000",
+                    "x-checker-data": {
+                        "package-name": "pkga"
+                    }
+                },
+                {
+                    "type": "archive",
+                    "url": "https://some-gibberish-phony-url.phony/releases/pkgb-4.5.6.tar.bz2",
+                    "sha256": "000000000000000000000000000000000000000000000000000000000000000000"
+                }
+            ]
+        }
+    ]
+}
+

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -30,6 +30,7 @@ from lib.externaldata import ExternalData, Checker
 import checker
 
 TEST_MANIFEST = os.path.join(tests_dir, 'org.externaldatachecker.Manifest.json')
+CVE_TEST_MANIFEST = os.path.join(tests_dir, 'org.cvechecker.Manifest.json')
 NUM_ARCHIVE_IN_MANIFEST = 1
 NUM_FILE_IN_MANIFEST = 1
 NUM_EXTRA_DATA_IN_MANIFEST = 5
@@ -41,6 +42,30 @@ class DummyChecker(Checker):
     def check(self, external_data):
         logging.debug('Phony checker checking external data %s and all is always good',
                       external_data.filename)
+
+
+class TestCVEChecker(unittest.TestCase):
+    def setUp(self):
+        logging.basicConfig(level=logging.DEBUG)
+        self.checker = checker.ManifestChecker(CVE_TEST_MANIFEST)
+
+    def test_check(self):
+        ext_data = self.checker.check()
+
+        self.assertEqual(len(ext_data), 2)
+
+        external_data_with_current_version = 0
+        for data in ext_data:
+            if data.current_version:
+                external_data_with_current_version += 1
+
+        # For now expect only 1 as pkg names aren't detected from URL
+        self.assertEqual(external_data_with_current_version, 1)
+
+        # For now just check the current version is correct
+        # later we will supply a new version and plg_name
+        self.assertEqual(ext_data[0].current_version, "1.2.3")
+
 
 class TestExternalDataChecker(unittest.TestCase):
 


### PR DESCRIPTION
This is an initial implementation of a CVEChecker, for now it only guesses the pkg_name and version - which it then adds to the debug output.

Let me know if you want this behind a flag for now ? eg `--experimental-cve-checker` or if it is fine as is.

```
$ ./src/flatpak-external-data-checker --json --verbose ~/Downloads/com.skype.Client.json 
DEBUG:root:CVEChecker: Found libsecret of the version 0.18.5
DEBUG:root:libsecret-0.18.5.tar.xz is not a debian-repo type ext data
DEBUG:root:libsecret-0.18.5.tar.xz is not a rotating-url type ext data
DEBUG:root:CVEChecker: Found v4l-utils of the version 1.12.5
DEBUG:root:v4l-utils-1.12.5.tar.bz2 is not a debian-repo type ext data
DEBUG:root:v4l-utils-1.12.5.tar.bz2 is not a rotating-url type ext data
DEBUG:root:CVEChecker: Found nss of the version 3.36.1
DEBUG:root:nss-3.36.1.tar.gz is not a debian-repo type ext data
DEBUG:root:nss-3.36.1.tar.gz is not a rotating-url type ext data
DEBUG:root:CVEChecker: Unknown type Type.EXTRA_DATA
DEBUG:root:skypeforlinux-64.deb is not a debian-repo type ext data
DEBUG:root:skypeforlinux-64.deb is not a rotating-url type ext data
```