### PR TITLE
DebianRepoChecker: improve flexibility of Debian repo checking

### DIFF
--- a/src/checkers/debianrepochecker.py
+++ b/src/checkers/debianrepochecker.py
@@ -40,7 +40,8 @@ import urllib
 from lib.externaldata import ExternalData, CheckerRegistry, Checker
 from lib import utils
 
-DEB_PACKAGES_URL = '{root}/dists/{dist}/{comp}/binary-{arch}/Packages'
+DEB_PACKAGES_DISTRO_URL = '{root}/dists/{dist}/{comp}/binary-{arch}/Packages'
+DEB_PACKAGES_EXACT_URL = '{root}/{dist}Packages'
 DEB_PACKAGES_URL_SUFFIX = ['.xz', '.bz2', '']
 
 class PkgInfo:
@@ -93,7 +94,7 @@ class DebianRepoChecker(Checker):
         package_name = external_data.checker_data['package-name']
         root = external_data.checker_data['root']
         dist = external_data.checker_data['dist']
-        component = external_data.checker_data['component']
+        component = external_data.checker_data.get('component', None)
         arch = self._translate_arch(external_data.arches[0])
         package = self._get_package_from_url(package_name, root, dist,
                                              component, arch)
@@ -155,8 +156,12 @@ class DebianRepoChecker(Checker):
         return packages
 
     def _get_package_from_url(self, package_name, root, dist, component, arch):
-        packages_url = DEB_PACKAGES_URL.format(root=root, dist=dist,
-                                               comp=component, arch=arch)
+        if dist[-1:] == '/' and component is None:
+            packages_url = DEB_PACKAGES_EXACT_URL.format(root=root, dist=dist)
+        else:
+            packages_url = DEB_PACKAGES_DISTRO_URL.format(root=root, dist=dist,
+                                                          comp=component, arch=arch)
+
         for suffix in DEB_PACKAGES_URL_SUFFIX:
             url = packages_url + suffix
             packages_page = self._load_url(url)

--- a/src/checkers/debianrepochecker.py
+++ b/src/checkers/debianrepochecker.py
@@ -95,6 +95,12 @@ class DebianRepoChecker(Checker):
         root = external_data.checker_data['root']
         dist = external_data.checker_data['dist']
         component = external_data.checker_data.get('component', None)
+
+        if not component and not dist.endswith('/'):
+            logging.warning('%s is missing Debian repo "component", for an ' \
+                            'exact URL "dist" must end with /', package_name)
+            return
+
         arch = self._translate_arch(external_data.arches[0])
         package = self._get_package_from_url(package_name, root, dist,
                                              component, arch)
@@ -156,9 +162,10 @@ class DebianRepoChecker(Checker):
         return packages
 
     def _get_package_from_url(self, package_name, root, dist, component, arch):
-        if dist[-1:] == '/' and component is None:
+        if dist.endswith('/') and component is None:
             packages_url = DEB_PACKAGES_EXACT_URL.format(root=root, dist=dist)
         else:
+            assert(component)
             packages_url = DEB_PACKAGES_DISTRO_URL.format(root=root, dist=dist,
                                                           comp=component, arch=arch)
 

--- a/src/checkers/debianrepochecker.py
+++ b/src/checkers/debianrepochecker.py
@@ -30,6 +30,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+import bz2
 import logging
 import lzma
 import os
@@ -40,7 +41,7 @@ from lib.externaldata import ExternalData, CheckerRegistry, Checker
 from lib import utils
 
 DEB_PACKAGES_URL = '{root}/dists/{dist}/{comp}/binary-{arch}/Packages'
-DEB_PACKAGES_XZ_URL = '{root}/dists/{dist}/{comp}/binary-{arch}/Packages.xz'
+DEB_PACKAGES_URL_SUFFIX = ['.xz', '.bz2', '']
 
 class PkgInfo:
     '''Represents a package in Debian's Packages repo file'''
@@ -128,6 +129,8 @@ class DebianRepoChecker(Checker):
             return None
         if packages_url.endswith('.xz'):
             packages_page = lzma.decompress(packages_page)
+        elif packages_url.endswith('.bz2'):
+            packages_page = bz2.decompress(packages_page)
 
         packages_page = packages_page.decode('utf-8')
 
@@ -154,10 +157,8 @@ class DebianRepoChecker(Checker):
     def _get_package_from_url(self, package_name, root, dist, component, arch):
         packages_url = DEB_PACKAGES_URL.format(root=root, dist=dist,
                                                comp=component, arch=arch)
-        packages_xz_url = DEB_PACKAGES_XZ_URL.format(root=root, dist=dist,
-                                                  comp=component, arch=arch)
-        urls = [packages_url, packages_xz_url]
-        for url in urls:
+        for suffix in DEB_PACKAGES_URL_SUFFIX:
+            url = packages_url + suffix
             packages_page = self._load_url(url)
             if packages_page is not None:
                 break


### PR DESCRIPTION
Add support for .bz2 Packages files, and repos with an exact URL which are usually specified in sources.list with just a base plus the subdirectory where Packages.* can be found.