### PR TITLE
Fix parsing more weird manifests

### DIFF
--- a/tests/org.externaldatachecker.Manifest.json
+++ b/tests/org.externaldatachecker.Manifest.json
@@ -1,4 +1,5 @@
 {
+    /* A comment, as accepted by json-glib and hence flatpak-builder */
     "app-id": "org.externaldata.Checker",
     "branch": "stable",
     "runtime": "org.freedesktop.Platform",

--- a/tests/org.externaldatachecker.Manifest.json
+++ b/tests/org.externaldatachecker.Manifest.json
@@ -9,6 +9,9 @@
     "finish-args": [
         "--extra-data=phonyextdata.tgz:000000000000000000000000000000000000000000000000000000000000000000:1234567::https://some-gibberish-phony-url.phony/phony-ext-data.tar.gz"
     ],
+    "_unused": "a multi-line string
+                    which is accepted by json-glib
+                even though it's not valid JSON",
     "modules": [
         "phony-shared-module.json",
         {

--- a/tests/org.externaldatachecker.Manifest.json
+++ b/tests/org.externaldatachecker.Manifest.json
@@ -10,14 +10,10 @@
         "--extra-data=phonyextdata.tgz:000000000000000000000000000000000000000000000000000000000000000000:1234567::https://some-gibberish-phony-url.phony/phony-ext-data.tar.gz"
     ],
     "modules": [
+        "phony-shared-module.json",
         {
             "name": "phony",
             "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://some-gibberish-phony-url.phony/phony-archive.tar.gz",
-                    "sha256": "000000000000000000000000000000000000000000000000000000000000000000"
-                },
                 {
                     "type": "file",
                     "only-arches": ["i386", "x86_64"],

--- a/tests/phony-shared-module.json
+++ b/tests/phony-shared-module.json
@@ -1,0 +1,10 @@
+{
+    "name": "phony-shared-module",
+    "sources": [
+        {
+            "type": "archive",
+            "url": "https://some-gibberish-phony-url.phony/phony-archive.tar.gz",
+            "sha256": "000000000000000000000000000000000000000000000000000000000000000000"
+        }
+    ]
+}


### PR DESCRIPTION
I noticed that Endless' internal job that runs this script over a bunch of manifests has been failing for a week or so. In some cases it's because the manifests really do need updating, but in other cases it's because the manifests use features that this script didn't support, namely:

* Referring to a module defined in an external file
* Multi-line strings, which are illegal JSON but accepted by json-glib so naturally are widely-used