### PR TITLE
Send non-default User-Agent

### DIFF
--- a/src/checkers/urlchecker.py
+++ b/src/checkers/urlchecker.py
@@ -20,18 +20,28 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+import logging
+import urllib.error
 
 from lib.externaldata import ExternalData, CheckerRegistry, Checker
 from lib import utils
 
-class URLChecker(Checker):
+log = logging.getLogger(__name__)
 
+
+class URLChecker(Checker):
     def check(self, external_data):
         try:
             utils.check_url_reachable(external_data.url)
+        except urllib.error.HTTPError as e:
+            log.warning('%s returned %s', external_data.url, e)
+            external_data.state = ExternalData.State.BROKEN
         except:
+            log.exception('Unexpected exception while checking %s',
+                          external_data.url, exc_info=True)
             external_data.state = ExternalData.State.BROKEN
         else:
             external_data.state = ExternalData.State.VALID
+
 
 CheckerRegistry.register_checker(URLChecker)

--- a/src/lib/utils.py
+++ b/src/lib/utils.py
@@ -20,8 +20,12 @@
 import hashlib
 import urllib.request
 
+# With the default urllib User-Agent, dl.discordapp.net returns 403
+USER_AGENT = 'flatpak-external-data-checker (+https://github.com/joaquimrocha/flatpak-external-data-checker)'
+HEADERS = {'User-Agent': USER_AGENT}
+
 def get_url_contents(url):
-    request = urllib.request.Request(url)
+    request = urllib.request.Request(url, headers=HEADERS)
 
     with urllib.request.urlopen(request) as response:
         return response.read()
@@ -29,12 +33,12 @@ def get_url_contents(url):
     return None
 
 def check_url_reachable(url):
-    request = urllib.request.Request(url, method='HEAD')
+    request = urllib.request.Request(url, method='HEAD', headers=HEADERS)
     response = urllib.request.urlopen(request)
     return response
 
 def get_extra_data_info_from_url(url):
-    request = urllib.request.Request(url)
+    request = urllib.request.Request(url, headers=HEADERS)
     data = None
     checksum = ''
     size = -1

--- a/src/lib/utils.py
+++ b/src/lib/utils.py
@@ -21,8 +21,9 @@ import hashlib
 import urllib.request
 
 # With the default urllib User-Agent, dl.discordapp.net returns 403
-USER_AGENT = 'flatpak-external-data-checker (+https://github.com/joaquimrocha/flatpak-external-data-checker)'
+USER_AGENT = 'flatpak-external-data-checker (+https://github.com/joaquimrocha/flatpak-external-data-checker)'  # noqa: E501
 HEADERS = {'User-Agent': USER_AGENT}
+
 
 def get_url_contents(url):
     request = urllib.request.Request(url, headers=HEADERS)
@@ -32,10 +33,12 @@ def get_url_contents(url):
 
     return None
 
+
 def check_url_reachable(url):
     request = urllib.request.Request(url, method='HEAD', headers=HEADERS)
     response = urllib.request.urlopen(request)
     return response
+
 
 def get_extra_data_info_from_url(url):
     request = urllib.request.Request(url, headers=HEADERS)


### PR DESCRIPTION
Without this, we see:

   WARNING:root:https://dl.discordapp.net/apps/linux/0.0.5/discord-0.0.5.tar.gz returned HTTP Error 403: Forbidden
   BROKEN: discord.tar.gz
       Unreachable URL: https://dl.discordapp.net/apps/linux/0.0.5/discord-0.0.5.tar.gz

Literally any other User-Agent beside the default seems to work.  This is only strictly needed in check_url_reachable() but it's polite to send a meaningful User-Agent anyway.

I've added a warning when a URL is unreachable including the HTTP error; previously there was no detail in the log output beside "BROKEN" but in fact it was a bug in the script, not an out-of-date URL.