### PR TITLE
debianrepochecker: reinitialize apt_pkg each time

### DIFF
--- a/src/checkers/debianrepochecker.py
+++ b/src/checkers/debianrepochecker.py
@@ -118,6 +118,7 @@ class DebianRepoChecker(Checker):
                 pass
 
             # Setup generic configuration
+            apt_pkg.init()
             apt_pkg.config.set('Dir', root)
             apt_pkg.config.set('Dir::State::status', dpkg_status)
             apt_pkg.config.set('Acquire::Languages', 'none')


### PR DESCRIPTION
Without this, the Dir::State::status path is preserved between calls to
this function. Since it's inside a temporary directory that is destroyed
when the function returns, this makes the second and subsequent calls
fail when constructing the apt.Cache():

    apt_pkg.Error: E:Could not open file
    /tmp/tmpvrmj49ts/var/lib/dpkg/status - open (2: No such file or
    directory), E:Problem opening /tmp/tmpvrmj49ts/var/lib/dpkg/status,
    E:The package lists or status file could not be parsed or opened.

This makes the tests pass again (sorry).