### PR TITLE
Include closed PRs when searching for existing PRs

### DIFF
--- a/src/flatpak-external-data-checker
+++ b/src/flatpak-external-data-checker
@@ -150,8 +150,14 @@ def open_pr(subject, body, branch):
     base = "master"
     head = "{}:{}".format(repo.owner.login, branch)
     pr_message = ((body or "") + "\n\n" + DISCLAIMER).strip()
-    for pr in origin_repo.get_pulls(base=base, head=head):
-        log.info("Found existing PR %s", pr.html_url)
+    # Include closed PRs – if the maintainer has closed our last PR, we don't want to
+    # open another one.
+    for pr in origin_repo.get_pulls(state="all", base=base, head=head):
+        log.info(
+            "Found existing %s PR: %s",
+            "merged" if pr.is_merged() else pr.state,
+            pr.html_url,
+        )
         return
 
     check_call(("git", "push", "-u", remote, branch))


### PR DESCRIPTION
If the maintainer closed our last PR (without merging; or perhaps they
merged it then reverted the change) they presumably have a good reason –
let's not spam them with more of the same change.

https://phabricator.endlessm.com/T19948