### PR TITLE
Support scraping version numbers from URLs, plus miscellaneous fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,9 +127,20 @@ the latest version:
 ```json
   "x-checker-data": {
                      "type": "rotating-url",
-                     "url": "http://example.com/last-version"
+                     "url": "http://example.com/last-version",
+                     "pattern": "http://example.com/foo-v([0-9.]+).tar.gz"
                     }
 ```
+
+The version number for the latest version can be detected in two ways:
+
+* If the filename ends with `.AppImage`, the version number is extracted
+  from the AppImage. (It is run in a `bwrap` sandbox.)
+* Otherwise, if `"pattern"` is specified in `"x-checker-data"`, the given
+  regular expression is matched against the full
+  URL for the latest version, and the first match group is taken to be the
+  version. (This follows the convention used by
+  [`debian/watch`](https://wiki.debian.org/debian/watch) files.)
 
 ## License and Copyright
 

--- a/src/checkers/flashchecker.py
+++ b/src/checkers/flashchecker.py
@@ -66,6 +66,7 @@ class FlashChecker(Checker):
         if browser not in BROWSER_TO_PAPI_MAP:
             log.warning('%s has an invalid browser (should be one of %s)',
                         external_data.filename, ', '.join(BROWSER_TO_PAPI_MAP))
+            external_data.state = ExternalData.State.BROKEN
             return
 
         arches = self._get_arches(external_data)
@@ -73,6 +74,7 @@ class FlashChecker(Checker):
             log.warning('%s has invalid only-arches (should be one of %s)',
                         external_data.filename,
                         ', '.join(f'[{arch}]' for arch in FLATPAK_TO_FLASH_ARCH_MAP))
+            external_data.state = ExternalData.State.BROKEN
             return
 
         flatpak_arch, flash_arch = arches

--- a/src/checkers/flashchecker.py
+++ b/src/checkers/flashchecker.py
@@ -63,10 +63,7 @@ class FlashChecker(Checker):
             return
 
         browser = external_data.checker_data['browser'].title()
-
-        try:
-            papi = BROWSER_TO_PAPI_MAP[browser]
-        except KeyError:
+        if browser not in BROWSER_TO_PAPI_MAP:
             log.warning('%s has an invalid browser (should be one of %s)',
                         external_data.filename, ', '.join(BROWSER_TO_PAPI_MAP))
             return

--- a/src/checkers/flashchecker.py
+++ b/src/checkers/flashchecker.py
@@ -90,10 +90,13 @@ class FlashChecker(Checker):
         latest_url = None
 
         for version in latest_version_data:
-            if (version['installation_type'] == 'Standalone' and version['browser'] == browser
-                    and version['installer_architecture'] == flash_arch):
-                assert version['platform'] == 'Linux'
-
+            if (
+                version['installation_type'] == 'Standalone' and
+                version['browser'] == browser and
+                version['installer_architecture'] == flash_arch and
+                version['platform'] == 'Linux' and
+                version["download_url"].endswith(".tar.gz")
+            ):
                 latest_version = version['Version']
                 latest_url = version['download_url']
                 break

--- a/src/checkers/flashchecker.py
+++ b/src/checkers/flashchecker.py
@@ -27,7 +27,7 @@ import urllib.error
 import urllib.request
 import urllib.parse
 
-from lib.externaldata import ExternalData, ExternalFile, Checker
+from lib.externaldata import ExternalData, Checker
 from lib import utils
 
 log = logging.getLogger(__name__)
@@ -105,7 +105,7 @@ class FlashChecker(Checker):
         assert latest_url is not None
 
         try:
-            _, _, checksum, size = utils.get_extra_data_info_from_url(latest_url)
+            new_version, _ = utils.get_extra_data_info_from_url(latest_url)
         except urllib.error.HTTPError as e:
             log.warning('%s returned %s', latest_url, e)
             external_data.state = ExternalData.State.BROKEN
@@ -114,6 +114,6 @@ class FlashChecker(Checker):
             external_data.state = ExternalData.State.BROKEN
         else:
             external_data.state = ExternalData.State.VALID
-            new_version = ExternalFile(latest_url, checksum, size, latest_version)
+            new_version = new_version._replace(version=latest_version)
             if not external_data.current_version.matches(new_version):
                 external_data.new_version = new_version

--- a/src/checkers/flashchecker.py
+++ b/src/checkers/flashchecker.py
@@ -107,10 +107,10 @@ class FlashChecker(Checker):
         try:
             _, _, checksum, size = utils.get_extra_data_info_from_url(latest_url)
         except urllib.error.HTTPError as e:
-            log.warning('%s returned %s', url, e)
+            log.warning('%s returned %s', latest_url, e)
             external_data.state = ExternalData.State.BROKEN
         except Exception:
-            log.exception('Unexpected exception while checking %s', url)
+            log.exception('Unexpected exception while checking %s', latest_url)
             external_data.state = ExternalData.State.BROKEN
         else:
             external_data.state = ExternalData.State.VALID

--- a/src/checkers/urlchecker.py
+++ b/src/checkers/urlchecker.py
@@ -71,7 +71,7 @@ class URLChecker(Checker):
 
         try:
             new_version, data = utils.get_extra_data_info_from_url(url)
-        except urllib.error.HTTPError as e:
+        except (urllib.error.HTTPError, urllib.error.URLError) as e:
             log.warning('%s returned %s', url, e)
             external_data.state = ExternalData.State.BROKEN
         except Exception:

--- a/src/lib/utils.py
+++ b/src/lib/utils.py
@@ -27,6 +27,8 @@ import subprocess
 import tempfile
 import urllib.request
 
+from .externaldata import ExternalFile
+
 from gi.repository import GLib
 
 log = logging.getLogger(__name__)
@@ -47,14 +49,16 @@ def get_extra_data_info_from_url(url):
     with urllib.request.urlopen(request, timeout=TIMEOUT_SECONDS) as response:
         real_url = response.geturl()
         data = response.read()
-        size = int(response.info().get('Content-Length', -1))
+        info = response.info()
 
-    if size == -1:
-        size = len(data)
+        if "Content-Length" in info:
+            size = int(info["Content-Length"])
+        else:
+            size = len(data)
 
     checksum = hashlib.sha256(data).hexdigest()
 
-    return real_url, data, checksum, size
+    return ExternalFile(real_url, checksum, size, None), data
 
 
 def extract_appimage_version(basename, data):

--- a/tests/com.adobe.FlashPlayer.NPAPI.json
+++ b/tests/com.adobe.FlashPlayer.NPAPI.json
@@ -1,0 +1,40 @@
+{
+  "app-id": "com.adobe.FlashPlayer.NPAPI",
+  "runtime": "org.mozilla.Firefox",
+  "sdk": "org.freedesktop.Sdk//18.08",
+  "modules": [
+    {
+      "name": "flash",
+      "sources": [
+        {
+          "type": "extra-data",
+          "filename": "flash_player_npapi_linux.tar.gz",
+          "only-arches": [
+            "x86_64"
+          ],
+          "url": "https://fpdownload.adobe.com/get/flashplayer/pdc/1.2.3.4/flash_player_npapi_linux.x86_64.tar.gz",
+          "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+          "size": 0,
+          "x-checker-data": {
+            "type": "flash",
+            "browser": "Firefox"
+          }
+        },
+        {
+          "type": "extra-data",
+          "filename": "flash_player_npapi_linux.tar.gz",
+          "only-arches": [
+            "i386"
+          ],
+          "url": "https://fpdownload.adobe.com/get/flashplayer/pdc/1.2.3.4/flash_player_npapi_linux.i386.tar.gz",
+          "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+          "size": 0,
+          "x-checker-data": {
+            "type": "flash",
+            "browser": "Firefox"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/org.externaldatachecker.Manifest.json
+++ b/tests/org.externaldatachecker.Manifest.json
@@ -78,7 +78,8 @@
                     "size": 1234567,
                     "x-checker-data": {
                         "type": "rotating-url",
-                        "url": "https://httpbin.org/redirect-to?url=https%3A%2F%2Fhttpbin.org%2Fimage%2Fjpeg&status_code=302"
+                        "url": "https://httpbin.org/redirect-to?url=https%3A%2F%2Fhttpbin.org%2Fimage%2Fjpeg%3Fversion=1.2.3.4&status_code=302",
+                        "pattern": ".*?version=([0-9.]+)$"
                     }
                 }
             ]

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -194,5 +194,13 @@ modules:
         outdated_ext_data = checker.get_outdated_external_data()
         self.assertEqual(len(outdated_ext_data), NUM_ALL_EXT_DATA)
 
+        for data in ext_data:
+            if data.filename == "dropbox.tgz":
+                self.assertEqual(data.new_version.version, "1.2.3.4")
+                break
+        else:
+            self.fail("dropbox.tgz data not found")
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_flashchecker.py
+++ b/tests/test_flashchecker.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# Copyright © 2019 Endless Mobile, Inc.
+#
+# Authors:
+#       Will Thompson <wjt@endlessm.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+import logging
+import os
+import sys
+import unittest
+
+tests_dir = os.path.dirname(__file__)
+checker_path = os.path.join(tests_dir, '..', 'src')
+sys.path.append(checker_path)
+
+from checker import ManifestChecker  # noqa: E402
+
+TEST_MANIFEST = os.path.join(tests_dir, "com.adobe.FlashPlayer.NPAPI.json")
+
+
+class TestFlashChecker(unittest.TestCase):
+    def setUp(self):
+        logging.basicConfig(level=logging.DEBUG)
+
+    def test_check(self):
+        checker = ManifestChecker(TEST_MANIFEST)
+        ext_data = checker.check()
+
+        self.assertEqual(len(ext_data), 2)
+
+        for data in ext_data:
+            self.assertIsNotNone(data.new_version)
+            self.assertRegex(data.new_version.url, r"^https?://.*\.tar.gz$")
+            self.assertIsInstance(data.new_version.size, int)
+            self.assertGreater(data.new_version.size, 1024 * 1024)
+            self.assertIsNotNone(data.new_version.version)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
To make a start on #17 for Dropbox, I added a way to scrape version numbers out of URLs with a regex. Then while doing a bit of supporting refactoring, I found the flashchecker has no tests, added one, and found a couple of bugs.