### PR TITLE
Fix rotating URL regression, improve PR messages, + misc

### DIFF
--- a/src/checker.py
+++ b/src/checker.py
@@ -192,31 +192,30 @@ class ManifestChecker:
             if data.state == ExternalData.State.BROKEN or data.new_version
         ]
 
-    def _update_manifest(self, path, datas):
-        changes = []
+    def _update_manifest(self, path, datas, changes):
         for data in datas:
             if data.new_version is None:
                 continue
 
             data.update()
             if data.new_version.version is not None:
-                changes.append(
-                    "Update {} to {}".format(
-                        data.filename, data.new_version.version
-                    )
+                message = "Update {} to {}".format(
+                    data.filename, data.new_version.version
                 )
             else:
-                changes.append("Update {}".format(data.filename))
+                message = "Update {}".format(data.filename)
+
+            changes[message] = None
 
         if changes:
             print("Updating {}".format(path))
             self._dump_manifest(path)
 
-        return changes
-
     def update_manifests(self):
         """Updates references to external data in manifests."""
-        changes = []
+        # We want a list, without duplicates; Python provides an
+        # insertion-order-preserving dictionary so we use that.
+        changes = OrderedDict()
         for path, datas in self._external_data.items():
-            changes.extend(self._update_manifest(path, datas))
-        return changes
+            self._update_manifest(path, datas, changes)
+        return list(changes)

--- a/src/checkers/urlchecker.py
+++ b/src/checkers/urlchecker.py
@@ -94,6 +94,9 @@ class URLChecker(Checker):
                 log.debug("%s is version %s", external_data.filename, version_string)
                 new_version = new_version._replace(version=version_string)
 
+            if not is_rotating:
+                new_version = new_version._replace(url=url)
+
             if external_data.current_version.matches(new_version):
                 log.debug("URL %s still valid", external_data.current_version.url)
                 external_data.state = ExternalData.State.VALID

--- a/tests/org.externaldatachecker.Manifest.json
+++ b/tests/org.externaldatachecker.Manifest.json
@@ -82,6 +82,14 @@
                         "pattern": ".*?version=([0-9.]+)$"
                     }
                 },
+                {
+                    "type": "extra-data",
+                    "filename": "hogs.txt",
+                    "url": "https://httpbin.org/base64/MzAtNTAgZmVyYWwgaG9ncyEK",
+                    "sha256": "e4d67702da4eeeb2f15629b65bf6767c028a511839c14ed44d9f34479eaa2b94",
+                    "size": 18
+                },
+
                 "phony-external-source.json"
             ]
         }

--- a/tests/org.externaldatachecker.Manifest.json
+++ b/tests/org.externaldatachecker.Manifest.json
@@ -34,7 +34,7 @@
                     "x-checker-data": {
                         "type": "debian-repo",
                         "package-name": "flatpak",
-                        "root": "http://ftp.debian.org/debian/",
+                        "root": "https://deb.debian.org/debian/",
                         "dist": "stable",
                         "component": "main"
                     }
@@ -49,7 +49,7 @@
                     "x-checker-data": {
                         "type": "debian-repo",
                         "package-name": "flatpak",
-                        "root": "http://ftp.debian.org/debian/",
+                        "root": "https://deb.debian.org/debian/",
                         "dist": "stable",
                         "component": "main"
                     }
@@ -64,7 +64,7 @@
                     "x-checker-data": {
                         "type": "debian-repo",
                         "package-name": "flatpak",
-                        "root": "http://ftp.debian.org/debian/",
+                        "root": "https://deb.debian.org/debian/",
                         "dist": "stable",
                         "component": "main"
                     }

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -34,7 +34,7 @@ from checker import ManifestChecker
 TEST_MANIFEST = os.path.join(tests_dir, 'org.externaldatachecker.Manifest.json')
 NUM_ARCHIVE_IN_MANIFEST = 1
 NUM_FILE_IN_MANIFEST = 1
-NUM_EXTRA_DATA_IN_MANIFEST = 6
+NUM_EXTRA_DATA_IN_MANIFEST = 7
 NUM_ALL_EXT_DATA = NUM_ARCHIVE_IN_MANIFEST + NUM_FILE_IN_MANIFEST + \
                    NUM_EXTRA_DATA_IN_MANIFEST
 
@@ -219,14 +219,27 @@ modules:
         self.assertEqual(len(extra_data), NUM_EXTRA_DATA_IN_MANIFEST)
 
         outdated_ext_data = checker.get_outdated_external_data()
-        self.assertEqual(len(outdated_ext_data), NUM_ALL_EXT_DATA)
+        self.assertEqual(len(outdated_ext_data), NUM_ALL_EXT_DATA - 1)
 
+        dropbox = self._find_by_filename(ext_data, "dropbox.tgz")
+        self.assertIsNotNone(dropbox)
+        self.assertEqual(dropbox.new_version.version, "1.2.3.4")
+        self.assertEqual(
+            dropbox.new_version.url,
+            "https://httpbin.org/image/jpeg?version=1.2.3.4",
+        )
+
+        # this URL is a redirect, but since it is not a rotating-url the URL
+        # should not be updated.
+        image = self._find_by_filename(ext_data, "image.jpeg")
+        self.assertIsNone(image)
+
+    def _find_by_filename(self, ext_data, filename):
         for data in ext_data:
-            if data.filename == "dropbox.tgz":
-                self.assertEqual(data.new_version.version, "1.2.3.4")
-                break
+            if data.filename == filename:
+                return data
         else:
-            self.fail("dropbox.tgz data not found")
+            return None
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* I introduced a regression in b249ee4; you can see the result at https://github.com/flathub/com.visualstudio.code/pull/99.
* https://github.com/endlessm/firefox-flatpak/pull/44 and other PRs with 2 files with the same name, one for i386 and one for x86_64, currently have rather unsightly commit messages.

This PR fixes both of these issues, and tweaks the tests a little.