### PR TITLE
Update <releases> in appdata

### DIFF
--- a/src/checkers/debianrepochecker.py
+++ b/src/checkers/debianrepochecker.py
@@ -38,6 +38,7 @@ import os
 import tempfile
 
 from lib.externaldata import Checker, ExternalFile
+from lib.utils import get_timestamp_from_url
 
 apt_pkg.init()
 
@@ -101,7 +102,11 @@ class DebianRepoChecker(Checker):
             package = cache[package_name]
             candidate = package.candidate
             new_version = ExternalFile(
-                candidate.uri, candidate.sha256, candidate.size, candidate.version
+                candidate.uri,
+                candidate.sha256,
+                candidate.size,
+                candidate.version,
+                timestamp=get_timestamp_from_url(candidate.uri),
             )
 
             if not external_data.current_version.matches(new_version):

--- a/src/checkers/debianrepochecker.py
+++ b/src/checkers/debianrepochecker.py
@@ -101,11 +101,19 @@ class DebianRepoChecker(Checker):
         with self._load_repo(root, dist, component, arch) as cache:
             package = cache[package_name]
             candidate = package.candidate
+            # http://www.fifi.org/doc/debian-policy/policy.html/ch-versions.html
+            #
+            # The version number format is: [epoch:]upstream_version[-debian_revision]
+            #
+            # The package management system will break the version number apart at the
+            # last hyphen in the string (if there is one) to determine the
+            # upstream_version and debian_revision.
+            upstream_version = candidate.version.rsplit("-", 1)[0]
             new_version = ExternalFile(
                 candidate.uri,
                 candidate.sha256,
                 candidate.size,
-                candidate.version,
+                upstream_version,
                 timestamp=get_timestamp_from_url(candidate.uri),
             )
 

--- a/src/checkers/debianrepochecker.py
+++ b/src/checkers/debianrepochecker.py
@@ -73,6 +73,15 @@ class LoggerAcquireProgress(apt.progress.text.AcquireProgress):
         return apt.progress.base.AcquireProgress.pulse(self, owner)
 
 
+def _get_timestamp_for_candidate(candidate):
+    # TODO: fetch package, parse changelog, get the date from there.
+    # python-apt can fetch changelogs from Debian and Ubuntu's changelog
+    # server, but most packages this checker will be used for are not from these repos.
+    # We'd have to open-code it.
+    # https://salsa.debian.org/apt-team/python-apt/blob/master/apt/package.py#L1245-1417
+    return get_timestamp_from_url(candidate.uri)
+
+
 class DebianRepoChecker(Checker):
     def __init__(self):
         self._pkgs_cache = {}
@@ -114,7 +123,7 @@ class DebianRepoChecker(Checker):
                 candidate.sha256,
                 candidate.size,
                 upstream_version,
-                timestamp=get_timestamp_from_url(candidate.uri),
+                timestamp=_get_timestamp_for_candidate(candidate),
             )
 
             if not external_data.current_version.matches(new_version):

--- a/src/checkers/firefoxchecker.py
+++ b/src/checkers/firefoxchecker.py
@@ -152,7 +152,14 @@ class FirefoxChecker(Checker):
 
                 url = '{}{}'.format(base_url, path)
                 log.debug("Inspecting %s", url)
+                # Unfortunately, the release date in firefox_versions.json does not
+                # seem to be updated when a point release is made, so we have to get it
+                # from the files' last-modified date.
+                #
+                # TODO: just make a HEAD request to get the date and size, and fill in
+                # the SHA256sum that we already know.
                 info, _ = utils.get_extra_data_info_from_url(url)
+                info = info._replace(version=version)
                 results[source_filename] = info
 
         return results

--- a/src/lib/appdata.py
+++ b/src/lib/appdata.py
@@ -1,0 +1,145 @@
+# Copyright © 2019 Endless Mobile, Inc.
+#
+# Authors:
+#       Will Thompson <wjt@endlessm.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""
+Add a new <release> at the start of the <releases> element in an appdata file,
+preserving as much formatting as is feasible and inserting that element if it is
+missing.
+"""
+
+from io import StringIO
+from xml.sax import make_parser
+from xml.sax.handler import property_lexical_handler
+from xml.sax.saxutils import XMLFilterBase, XMLGenerator
+
+
+class AddVersionFilter(XMLFilterBase):
+    def __init__(self, version, date, parent=None):
+        super().__init__(parent)
+
+        self._version = version
+        self._date = date
+        self._context = []
+        self._emitted_release = False
+        self._releases_padding = ""
+
+    @property
+    def outside_root_element(self):
+        return not self._context
+
+    @property
+    def _in_releases(self):
+        return self._context[1:] == ["releases"]
+
+    def _emit_release(self):
+        super().startElement("release", {"version": self._version, "date": self._date})
+        # TODO: add placeholder <description> if other <release> entries have one
+        super().endElement("release")
+        super().characters(self._releases_padding)
+        self._emitted_release = True
+
+    def startElement(self, name, attrs):
+        if self._in_releases and not self._emitted_release:
+            self._emit_release()
+
+        super().startElement(name, attrs)
+
+        self._context.append(name)
+
+    def characters(self, chars):
+        if self._in_releases and not self._emitted_release and chars.isspace():
+            self._releases_padding += chars
+
+        super().characters(chars)
+
+    def endElement(self, name):
+        if self._in_releases and not self._emitted_release:
+            super().characters("\n    ")
+            self._emit_release()
+            super().characters("\n  ")
+
+        self._context.pop()
+
+        if not self._context and not self._emitted_release:
+            # No <releases> found; synthesize one
+            super().characters("  ")
+            super().startElement("releases", {})
+            super().characters("\n    ")
+            self._emit_release()
+            super().characters("\n  ")
+            super().endElement("releases")
+            super().characters("\n")
+
+        super().endElement(name)
+
+
+class VerbatimLexicalHandler:
+    """Implements the poorly-documented LexicalHandler interface."""
+
+    def __init__(self, reader, stream):
+        self._reader = reader
+        self._stream = stream
+
+    def comment(self, text):
+        self._stream.write("<!--")
+        self._stream.write(text)
+        self._stream.write("-->")
+
+        # Aggravating hack alert!
+        #
+        # appdata files often include a copyright comment between the <?xml
+        # declaration and the root element. In some cases, there are two.
+        # Unfortunately, there is no representation in the SAX API for
+        # whitespace that occurs outside any element, and there's normally
+        # a newline between the comment and the opening element (or the next
+        # comment).
+        #
+        # Work around this by writing a newline in this case; this requires some
+        # coordination between the reader and this writer.
+        if self._reader.outside_root_element:
+            self._stream.write("\n")
+
+    def startCDATA(self, *args):
+        raise NotImplementedError
+
+    def endCDATA(self, *args):
+        raise NotImplementedError
+
+    def endDTD(self, *args):
+        raise NotImplementedError
+
+
+def add_release(in_path_or_stream, out, version, date):
+    reader = AddVersionFilter(version, date, make_parser())
+    lexical_handler = VerbatimLexicalHandler(reader, out)
+    handler = XMLGenerator(out, encoding="UTF-8", short_empty_elements=True)
+    reader.setContentHandler(handler)
+    reader.setProperty(property_lexical_handler, lexical_handler)
+    reader.parse(in_path_or_stream)
+
+
+def add_release_to_file(appdata_path, version, date):
+    with StringIO() as buf:
+        add_release(appdata_path, buf, version, date)
+
+        with open(appdata_path, "w") as f:
+            xml = buf.getvalue()
+            f.write(xml)
+            if not xml.endswith("\n"):
+                f.write("\n")

--- a/src/lib/externaldata.py
+++ b/src/lib/externaldata.py
@@ -33,7 +33,7 @@ class ModuleData:
         self.external_data = []
 
 
-class ExternalFile(namedtuple("ExternalFile", ("url", "checksum", "size", "version"))):
+class ExternalFile(namedtuple("ExternalFile", ("url", "checksum", "size", "version", "timestamp"))):
     __slots__ = ()
 
     def matches(self, other):
@@ -72,7 +72,7 @@ class ExternalData(abc.ABC):
         self.arches = arches
         self.type = data_type
         self.checker_data = checker_data or {}
-        self.current_version = ExternalFile(url, checksum, int(size), None)
+        self.current_version = ExternalFile(url, checksum, int(size), None, None)
         self.new_version = None
         self.state = ExternalData.State.UNKNOWN
 

--- a/tests/test_appdata.py
+++ b/tests/test_appdata.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+# Copyright © 2019 Endless Mobile, Inc.
+#
+# Authors:
+#       Will Thompson <wjt@endlessm.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+import os
+import unittest
+import sys
+from io import StringIO
+
+# Yuck!
+tests_dir = os.path.dirname(__file__)
+checker_path = os.path.join(tests_dir, "..", "src")
+sys.path.append(checker_path)
+
+from lib.appdata import add_release  # noqa: E402
+
+
+class TestAddRelease(unittest.TestCase):
+    def _do_test(self, before, expected):
+        in_ = StringIO(before)
+        out = StringIO()
+        add_release(in_, out, "4.5.6", "2020-02-02")
+        self.assertMultiLineEqual(out.getvalue(), expected)
+
+    def test_simple(self):
+        self._do_test(
+            """
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <releases>
+    <release version="1.2.3" date="2019-01-01"/>
+  </releases>
+</component>
+            """.strip(),
+            """
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <releases>
+    <release version="4.5.6" date="2020-02-02"/>
+    <release version="1.2.3" date="2019-01-01"/>
+  </releases>
+</component>
+            """.strip(),
+        )
+
+    def test_mixed_indentation(self):
+        """This input uses 3-space indentation for one existing <release> and 4-space
+        for another. Match the top one."""
+        self._do_test(
+            """
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+   <releases>
+      <release version="1.2.3" date="2019-01-01"/>
+       <release version="1.2.3" date="2019-01-01"/>
+   </releases>
+</component>
+            """.strip(),
+            """
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+   <releases>
+      <release version="4.5.6" date="2020-02-02"/>
+      <release version="1.2.3" date="2019-01-01"/>
+       <release version="1.2.3" date="2019-01-01"/>
+   </releases>
+</component>
+            """.strip(),
+        )
+
+    @unittest.expectedFailure
+    def test_release_attribute_ordering(self):
+        """It would be nice to follow the attribute order on any existing <release>s.
+        Currently we always emit version then date. I checked 18 repos and it was a
+        10-8 split."""
+        self._do_test(
+            """
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <releases>
+    <release date="2019-01-01" version="1.2.3"/>
+  </releases>
+</component>
+            """.strip(),
+            """
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <releases>
+    <release date="2020-02-02" version="4.5.6"/>
+    <release date="2019-01-01" version="1.2.3"/>
+  </releases>
+</component>
+            """.strip(),
+        )
+
+    def test_comment(self):
+        self._do_test(
+            """
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <!-- I am the walrus -->
+  <releases>
+    <release version="1.2.3" date="2019-01-01"/>
+  </releases>
+</component>
+            """.strip(),
+            """
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <!-- I am the walrus -->
+  <releases>
+    <release version="4.5.6" date="2020-02-02"/>
+    <release version="1.2.3" date="2019-01-01"/>
+  </releases>
+</component>
+            """.strip(),
+        )
+
+    def test_no_releases(self):
+        self._do_test(
+            """
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+</component>
+            """.strip(),
+            """
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <releases>
+    <release version="4.5.6" date="2020-02-02"/>
+  </releases>
+</component>
+            """.strip(),
+        )
+
+    def test_empty_releases(self):
+        """No whitespace is generated between <release /> and </releases>."""
+        self._do_test(
+            """
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <releases/>
+</component>
+            """.strip(),
+            """
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <releases>
+    <release version="4.5.6" date="2020-02-02"/>
+  </releases>
+</component>
+            """.strip(),
+            # but we can live with it in this edge case for now
+        )
+
+    def test_double_comment_within_root(self):
+        self._do_test(
+            """
+<?xml version="1.0" encoding="UTF-8"?>
+<application>
+<!-- Copyright 2019 Rupert Monkey <rupert@gnome.org> -->
+ <!--
+EmailAddress: billg@example.com
+SentUpstream: 2014-05-22
+-->
+</application>
+            """.strip(),
+            """
+<?xml version="1.0" encoding="UTF-8"?>
+<application>
+<!-- Copyright 2019 Rupert Monkey <rupert@gnome.org> -->
+ <!--
+EmailAddress: billg@example.com
+SentUpstream: 2014-05-22
+-->
+  <releases>
+    <release version="4.5.6" date="2020-02-02"/>
+  </releases>
+</application>
+            """.strip(),
+        )
+
+    def test_comment_outside_root(self):
+        # appdata files often include a copyright comment between the <?xml
+        # declaration and the root element. In some cases, there are two.
+        # Unfortunately, there is no representation in the SAX API for
+        # whitespace that occurs outside any element. Test that the
+        # conventional newline after such comments is preserved.
+
+        self._do_test(
+            """
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2019 Rupert Monkey <rupert@gnome.org> -->
+<!--
+EmailAddress: billg@example.com
+SentUpstream: 2014-05-22
+-->
+<application>
+</application>
+            """.strip(),
+            """
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2019 Rupert Monkey <rupert@gnome.org> -->
+<!--
+EmailAddress: billg@example.com
+SentUpstream: 2014-05-22
+-->
+<application>
+  <releases>
+    <release version="4.5.6" date="2020-02-02"/>
+  </releases>
+</application>
+            """.strip(),
+        )
+
+    def test_amp_as_amp(self):
+        self._do_test(
+            """
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <name>🍦 &amp; 🎂</name>
+</component>
+            """.strip(),
+            """
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <name>🍦 &amp; 🎂</name>
+  <releases>
+    <release version="4.5.6" date="2020-02-02"/>
+  </releases>
+</component>
+            """.strip(),
+        )
+
+    @unittest.expectedFailure
+    def test_amp_as_codepoint(self):
+        """&#38; becomes &amp;."""
+        self._do_test(
+            """
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <name>🦝 &#38; 🍒</name>
+</component>
+            """.strip(),
+            """
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <name>🦝 &#38; 🍒</name>
+  <releases>
+    <release version="4.5.6" date="2020-02-02"/>
+  </releases>
+</component>
+            """.strip(),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Doing this without generating a huge diff was a lot more involved than I
expected, but this seems to work OK now.

I have tested this locally against:

* endlessm/eos-google-chrome-app, which currently has no `<releases>`: the checker adds it
* flathub/us.zoom.Zoom, which already has `<releases>`: it prepends a new one, albeit with the attributes in a different order to the existing entries. There's a test marked `expectedFailure` for this; the order has no semantic impact and the 18 repos I checked have no trend towards one or another.

Fixes #17.