### PR TITLE
htmlchecker: Add HTML checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,20 @@ The version number for the latest version can be detected in two ways:
   version. (This follows the convention used by
   [`debian/watch`](https://wiki.debian.org/debian/watch) files.)
 
+#### HTML checker
+
+Both the version number and the download URL will be gathered from a static
+HTML page which contains this information:
+
+```json
+"x-checker-data": {•
+    "type": "html",•
+    "url": "https://www.example.com/download.html",
+    "version-pattern": "The latest version is ([\d\.-]*)",
+    "url-pattern": "https://www.example.com/pub/foo/v(\d+)/foo.tar.gz"
+}•
+```
+
 #### Debian repo checker
 
 For the **DebianRepoChecker**, which deals only with deb packages, it

--- a/src/checkers/__init__.py
+++ b/src/checkers/__init__.py
@@ -2,6 +2,7 @@ from .debianrepochecker import DebianRepoChecker
 from .firefoxchecker import FirefoxChecker
 from .flashchecker import FlashChecker
 from .urlchecker import URLChecker
+from .htmlchecker import HTMLChecker
 
 
 ALL_CHECKERS = [
@@ -9,4 +10,5 @@ ALL_CHECKERS = [
     FirefoxChecker,
     FlashChecker,
     URLChecker,
+    HTMLChecker
 ]

--- a/src/checkers/htmlchecker.py
+++ b/src/checkers/htmlchecker.py
@@ -1,0 +1,89 @@
+# HTML Checker: A checker to see if the url is pointing to the latest HTML Player.
+#
+# Consult the README for information on how to use this checker.
+#
+# Copyright © 2019 Bastien Nocera <hadess@hadess.net>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+import logging
+import re
+import urllib.error
+import urllib.request
+import urllib.parse
+
+from lib.externaldata import ExternalData, Checker
+from lib import utils
+
+log = logging.getLogger(__name__)
+
+def get_latest(checker_data, pattern_name, html):
+    """
+    If checker_data contains a "pattern", matches 'html' against it and returns the
+    first capture group (which is assumed to be the version or URL).
+    """
+    try:
+        pattern = checker_data[pattern_name]
+    except KeyError:
+        return None
+
+    m = re.search(pattern, html)
+    if m is None:
+        return None
+
+    return m.group(1)
+
+
+class HTMLChecker(Checker):
+    def _should_check(self, external_data):
+        return external_data.checker_data.get('type') == 'html'
+
+    def check(self, external_data):
+        if not self._should_check(external_data):
+            log.debug('%s is not a html type ext data', external_data.filename)
+            return
+
+        url = external_data.checker_data.get('url')
+        log.debug("Getting extra data info from %s; may take a while", url)
+        resp = urllib.request.urlopen(url)
+        html = resp.read().decode()
+
+        latest_version = get_latest(external_data.checker_data,
+                'version-pattern', html)
+        latest_url = get_latest(external_data.checker_data,
+                'url-pattern', html)
+        if not latest_version:
+            log.warning('%s had no available version information', external_data.filename)
+        if not latest_url:
+            log.warning('%s had no available URL', external_data.filename)
+        if not latest_version or not latest_url:
+            return
+
+        assert latest_version is not None
+        assert latest_url is not None
+
+        try:
+            new_version, _ = utils.get_extra_data_info_from_url(latest_url)
+        except urllib.error.HTTPError as e:
+            log.warning('%s returned %s', latest_url, e)
+            external_data.state = ExternalData.State.BROKEN
+        except Exception:
+            log.exception('Unexpected exception while checking %s', latest_url)
+            external_data.state = ExternalData.State.BROKEN
+        else:
+            external_data.state = ExternalData.State.VALID
+            new_version = new_version._replace(version=latest_version)
+            if not external_data.current_version.matches(new_version):
+                external_data.new_version = new_version

--- a/tests/com.adobe.Flash-Player-Projector.json
+++ b/tests/com.adobe.Flash-Player-Projector.json
@@ -1,0 +1,105 @@
+{
+    "app-id" : "com.adobe.Flash-Player-Projector",
+    "runtime" : "org.freedesktop.Platform",
+    "runtime-version" : "19.08",
+    "sdk" : "org.freedesktop.Sdk",
+    "command" : "flashplayer",
+    "tags": ["proprietary"],
+    "finish-args" : [
+        /* X11 + XShm access */
+        "--share=ipc", "--socket=x11",
+        /* GPU acceleration */
+        "--device=dri",
+        /* Play sounds */
+        "--socket=pulseaudio",
+        /* Get access to the files */
+        "--filesystem=host:ro",
+        "--filesystem=xdg-run/gvfs:ro"
+    ],
+    "modules" : [
+        {
+            "name" : "flashplayer",
+            "buildsystem" : "simple",
+            "build-commands" : [
+                "make install",
+                "install -D -t /app/bin/ apply_extra",
+                "install flashplayer /app/bin",
+                "install -Dm644 64x64_com.adobe.Flash-Player-Projector.png /app/share/icons/hicolor/64x64/apps/com.adobe.Flash-Player-Projector.png",
+                "install -Dm644 128x128_com.adobe.Flash-Player-Projector.png /app/share/icons/hicolor/128x128/apps/com.adobe.Flash-Player-Projector.png",
+                "install -Dm644 256x256_com.adobe.Flash-Player-Projector.png /app/share/icons/hicolor/256x256/apps/com.adobe.Flash-Player-Projector.png",
+                "install -Dm644 -t /app/share/icons/hicolor/scalable/apps/ com.adobe.Flash-Player-Projector.svg",
+                "install -Dm644 -t /app/share/applications/ com.adobe.Flash-Player-Projector.desktop",
+                "install -Dm644 -t /app/share/metainfo/ com.adobe.Flash-Player-Projector.appdata.xml"
+            ],
+            "sources" : [
+                {
+                    "type" : "script",
+                    "dest-filename" : "flashplayer",
+                    "commands": [
+                       "LD_PRELOAD=/app/lib/libfix-config-location.so exec /app/extra/flashplayer \"$@\""
+                    ]
+                },
+                {
+                   "type" : "script",
+                   "dest-filename": "apply_extra",
+                   "commands": [
+                       "tar xzf flash_player_sa_linux.x86_64.tar.gz",
+                       "rm -f flash_player_sa_linux.x86_64.tar.gz"
+                   ]
+                },
+                {
+                   "type" : "file",
+                   "path" : "Makefile"
+                },
+                {
+                   "type" : "file",
+                   "path" : "fix-config-location.c"
+                },
+                {
+                   "type" : "file",
+                   "path" : "directories.h"
+                },
+                {
+                    "type" : "extra-data",
+                    "filename" : "flash_player_sa_linux.x86_64.tar.gz",
+                    "only-arches": ["x86_64"],
+                    "url" : "https://fpdownload.macromedia.com/pub/flashplayer/updaters/31/flash_player_sa_linux.x86_64.tar.gz",
+                    "sha256" : "0000000000000000000000000000000000000000000000000000000000000000",
+                    "size" : 0,
+                    "x-checker-data": {
+                        "type": "html",
+                        "url": "https://www.adobe.com/support/flashplayer/debug_downloads.html",
+                        "version-pattern": "The latest versions are <span>([\\d\\.-]*)<\\/span>",
+                        "url-pattern": "(https:\\/\\/fpdownload\\.macromedia\\.com\\/pub\\/flashplayer\\/updaters\\/\\d+\\/flash_player_sa_linux\\.x86_64\\.tar\\.gz)"
+                    }
+                },
+                {
+                    "type" : "file",
+                    "url" : "https://helpx.adobe.com/content/dam/help/mnemonics/flashplayer_app_RGB.svg",
+                    "sha256" : "97fc022ae65f37a2e36d6be71c651dbd3d2f7c82f9f89ba13ea3e6cf9be3144c",
+                    "dest-filename" : "com.adobe.Flash-Player-Projector.svg"
+                },
+                {
+                    "type" : "file",
+                    "path" : "256x256_com.adobe.Flash-Player-Projector.png"
+                },
+                {
+                    "type" : "file",
+                    "path" : "128x128_com.adobe.Flash-Player-Projector.png"
+                },
+                {
+                    "type" : "file",
+                    "path" : "64x64_com.adobe.Flash-Player-Projector.png"
+                },
+                {
+                    "type" : "file",
+                    "path" : "com.adobe.Flash-Player-Projector.desktop"
+                },
+                {
+                    "type" : "file",
+                    "path" : "com.adobe.Flash-Player-Projector.appdata.xml"
+                }
+            ]
+        }
+    ]
+}

--- a/tests/test_htmlchecker.py
+++ b/tests/test_htmlchecker.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# Copyright © 2019 Endless Mobile, Inc.
+#
+# Authors:
+#       Andre Moreira Magalhaes <andre@endlessm.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+import logging
+import os
+import sys
+import unittest
+
+tests_dir = os.path.dirname(__file__)
+checker_path = os.path.join(tests_dir, '..', 'src')
+sys.path.append(checker_path)
+
+from lib.externaldata import ExternalData
+from checker import ManifestChecker
+
+TEST_MANIFEST = os.path.join(tests_dir, "com.adobe.Flash-Player-Projector.json")
+
+
+class TestFirefoxChecker(unittest.TestCase):
+    def setUp(self):
+        logging.basicConfig(level=logging.DEBUG)
+
+    def test_check(self):
+        checker = ManifestChecker(TEST_MANIFEST)
+        ext_data = checker.check()
+
+        removed = [ data for data in ext_data if data.state == ExternalData.State.REMOVED ]
+        added = [ data for data in ext_data if data.state == ExternalData.State.ADDED ]
+        updated = [ data for data in ext_data if data.state == ExternalData.State.VALID ]
+
+        self.assertEqual(len(removed), 0)
+        self.assertEqual(len(added), 0)
+        self.assertEqual(len(updated), 1)
+
+        data = updated[0]
+        self.assertEqual(data.filename, "flash_player_sa_linux.x86_64.tar.gz")
+        self.assertIsNotNone(data.new_version)
+        self.assertRegex(data.new_version.url, r"^https?://fpdownload\.macromedia\.com/pub/flashplayer/updaters/.+/flash_player_sa_linux\.x86_64\.tar\.gz$")
+        self.assertIsInstance(data.new_version.size, int)
+        self.assertGreater(data.new_version.size, 0)
+        self.assertIsNotNone(data.new_version.checksum)
+        self.assertIsInstance(data.new_version.checksum, str)
+        self.assertNotEqual(data.new_version.checksum, "0000000000000000000000000000000000000000000000000000000000000000")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
As documented in README.md

Completely untested, as I couldn't figure out how to run it that didn't involve docker, or GitHub Python modules.

I'd like to use it with https://github.com/flathub/com.adobe.Flash-Player-Projector and the following `x-checker-data`:
```json
"x-checker-data": {
    "type": "html",
    "url": "https://www.adobe.com/support/flashplayer/debug_downloads.html",
    "version-pattern": "The latest versions are <span>([\d\.-]*)</span>",
    "url-pattern": "https://fpdownload.macromedia.com/pub/flashplayer/updaters/(\d+)/flash_player_sa_linux.x86_64.tar.gz"
}
```

The patterns are the ones from https://release-monitoring.org/project/17854