### PR TITLE
utils: retry on socket.timeout

### DIFF
--- a/src/lib/utils.py
+++ b/src/lib/utils.py
@@ -24,6 +24,7 @@ import hashlib
 import logging
 import os
 import re
+import socket
 import subprocess
 import tempfile
 import urllib.request
@@ -65,7 +66,7 @@ def get_timestamp_from_url(url):
 
 
 @retry(
-    retry=retry_if_exception_type(ConnectionResetError),
+    retry=retry_if_exception_type((ConnectionResetError, socket.timeout)),
     stop=stop_after_attempt(3),
     wait=wait_fixed(2),
     before_sleep=before_sleep_log(log, logging.DEBUG),


### PR DESCRIPTION
I was emailed last night because of a transient failure to fetch
viber.deb:

    DEBUG:src.checkers.urlchecker:Getting extra data info from https://download.cdn.viber.com/cdn/desktop/Linux/viber.deb; may take a while
    ERROR:src.checkers.urlchecker:Unexpected exception while checking https://download.cdn.viber.com/cdn/desktop/Linux/viber.deb
    Traceback (most recent call last):
      File "/home/jenkins/workspace/check-flatpak-external-apps-pipeline/src/checkers/urlchecker.py", line 73, in check
        new_version, data = utils.get_extra_data_info_from_url(url)
      File "/usr/lib/python3/dist-packages/tenacity/__init__.py", line 241, in wrapped_f
        return self.call(f, *args, **kw)
      File "/usr/lib/python3/dist-packages/tenacity/__init__.py", line 330, in call
        start_time=start_time)
      File "/usr/lib/python3/dist-packages/tenacity/__init__.py", line 279, in iter
        return fut.result()
      File "/usr/lib/python3.7/concurrent/futures/_base.py", line 425, in result
        return self.__get_result()
      File "/usr/lib/python3.7/concurrent/futures/_base.py", line 384, in __get_result
        raise self._exception
      File "/usr/lib/python3/dist-packages/tenacity/__init__.py", line 333, in call
        result = fn(*args, **kwargs)
      File "/home/jenkins/workspace/check-flatpak-external-apps-pipeline/src/lib/utils.py", line 80, in get_extra_data_info_from_url
        with urllib.request.urlopen(request, timeout=TIMEOUT_SECONDS) as response:
      File "/usr/lib/python3.7/urllib/request.py", line 222, in urlopen
        return opener.open(url, data, timeout)
      File "/usr/lib/python3.7/urllib/request.py", line 525, in open
        response = self._open(req, data)
      File "/usr/lib/python3.7/urllib/request.py", line 543, in _open
        '_open', req)
      File "/usr/lib/python3.7/urllib/request.py", line 503, in _call_chain
        result = func(*args)
      File "/usr/lib/python3.7/urllib/request.py", line 1360, in https_open
        context=self._context, check_hostname=self._check_hostname)
      File "/usr/lib/python3.7/urllib/request.py", line 1320, in do_open
        r = h.getresponse()
      File "/usr/lib/python3.7/http/client.py", line 1321, in getresponse
        response.begin()
      File "/usr/lib/python3.7/http/client.py", line 296, in begin
        version, status, reason = self._read_status()
      File "/usr/lib/python3.7/http/client.py", line 257, in _read_status
        line = str(self.fp.readline(_MAXLINE + 1), "iso-8859-1")
      File "/usr/lib/python3.7/socket.py", line 589, in readinto
        return self._sock.recv_into(b)
      File "/usr/lib/python3.7/ssl.py", line 1052, in recv_into
        return self.read(nbytes, buffer)
      File "/usr/lib/python3.7/ssl.py", line 911, in read
        return self._sslobj.read(len, buffer)
    socket.timeout: The read operation timed out
    BROKEN: viber.deb
     Unreachable URL: https://download.cdn.viber.com/cdn/desktop/Linux/viber.deb

    WARNING:src.main:Can't automatically fix any of the above issues

Add socket.timeout to the set of exception types for which
get_extra_data_info_from_url() will retry a few times.