### PR TITLE
Add "canonicalize-manifest"  tool

### DIFF
--- a/canonicalize-manifest
+++ b/canonicalize-manifest
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+#
+# canonicalize-manifest: Reformat a manifest to match the output of the full checker.
+#
+# Copyright © 2019 Endless Mobile, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+import argparse
+import sys
+from pathlib import Path
+
+exe = Path(sys.argv[0]).resolve()
+sys.path.insert(0, str(exe.parent))
+
+from src.lib.utils import read_manifest, dump_manifest  # noqa: E402
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Reformat a manifest to match the output of the full checker."
+    )
+    parser.add_argument(
+        "manifest_path", help="Path to JSON or YAML manifest to reformat"
+    )
+    args = parser.parse_args()
+
+    dump_manifest(read_manifest(args.manifest_path), args.manifest_path)

--- a/src/checker.py
+++ b/src/checker.py
@@ -37,10 +37,6 @@ from gi.repository import Json  # noqa: E402
 log = logging.getLogger(__name__)
 
 
-class NoManifestCheckersFound(Exception):
-    pass
-
-
 class ManifestChecker:
     yaml = YAML()
     # ruamel preserves some formatting (such as comments and blank lines) but
@@ -55,6 +51,7 @@ class ManifestChecker:
 
         # Initialize checkers
         self._checkers = [checker() for checker in ALL_CHECKERS]
+        assert self._checkers
 
         # Map from filename to parsed contents of that file. Sources may be
         # specified as references to external files, which is why there can be
@@ -154,10 +151,6 @@ class ManifestChecker:
         It initializes an internal list of all the external data objects
         found in the manifest.
         '''
-
-        if not self._checkers:
-            raise NoManifestCheckersFound()
-
         ext_data_checked = []
 
         for _, module_data in self._modules_data.items():

--- a/src/checkers/htmlchecker.py
+++ b/src/checkers/htmlchecker.py
@@ -36,15 +36,18 @@ def get_latest(checker_data, pattern_name, html):
     first capture group (which is assumed to be the version or URL).
     """
     try:
-        pattern = checker_data[pattern_name]
+        pattern = re.compile(checker_data[pattern_name])
     except KeyError:
         return None
 
-    m = re.search(pattern, html)
+    m = pattern.search(html)
     if m is None:
+        log.debug("%s %s did not match", pattern_name, pattern)
         return None
 
-    return m.group(1)
+    result = m.group(1)
+    log.debug("%s %s matched: %s", pattern_name, pattern, result)
+    return result
 
 
 class HTMLChecker(Checker):

--- a/src/main.py
+++ b/src/main.py
@@ -206,11 +206,7 @@ def main():
     manifest_checker = checker.ManifestChecker(args.manifest)
     filter_type = ExternalData.TYPES.get(args.filter_type)
 
-    try:
-        manifest_checker.check(filter_type)
-    except checker.NoManifestCheckersFound:
-        sys.stderr.write('No manifest checkers were found\n')
-        exit(2)
+    manifest_checker.check(filter_type)
 
     if print_outdated_external_data(manifest_checker):
         if args.update or args.commit_only:


### PR DESCRIPTION
This was requested by @hadess at https://github.com/flathub/com.adobe.Flash-Player-Projector/pull/28#issuecomment-553338831 as a way to reformat the JSON/YAML ahead of time so that PRs from this tool are clearer. I guess there is an argument that the tool should produce 2 separate commits, one with any reformatting but no semantic changes, and another with just the actual changes, but this is easier for now.

While I was here, I chucked in a patch that's been lying around in my tree for a few weeks, and some additional debug output from htmlchecker.