### PR TITLE
wrappers: Remove us.zoom.Zoom

### DIFF
--- a/wrappers/jenkins-check-flatpak-external-apps
+++ b/wrappers/jenkins-check-flatpak-external-apps
@@ -32,7 +32,6 @@ EXTERNAL_MANIFESTS = (
     ExternalManifest("git@github.com:flathub/com.visualstudio.code"),
     ExternalManifest("git@github.com:flathub/io.exodus.Exodus"),
     ExternalManifest("git@github.com:flathub/org.geogebra.GeoGebra"),
-    ExternalManifest("git@github.com:flathub/us.zoom.Zoom"),
 )
 
 


### PR DESCRIPTION
Flathub enabled Actions-backed external-data-checker for Zoom [today][1]. Let's see how it goes.

[1]: https://github.com/flathub/us.zoom.Zoom/commit/61980e55fd7e1b9f5e948c964c683bc46f5e7a8d