### PR TITLE
Fix Firefox checker

### DIFF
--- a/src/checker.py
+++ b/src/checker.py
@@ -198,7 +198,7 @@ class ManifestChecker:
                 message = "Added {}".format(data.filename)
             elif data.state == ExternalData.State.REMOVED:
                 message = "Removed {}".format(data.filename)
-            if data.new_version.version is not None:
+            elif data.new_version.version is not None:
                 message = "Update {} to {}".format(
                     data.filename, data.new_version.version
                 )

--- a/src/checker.py
+++ b/src/checker.py
@@ -85,11 +85,10 @@ class ManifestChecker:
             module_data = ModuleData(module_name, module_path, module)
 
             sources = module.get('sources', [])
-            inline_sources = [ source for source in sources if not isinstance(source, str) ]
             external_sources = [ source for source in sources if isinstance(source, str) ]
 
             external_data = self._external_data.setdefault(module_path, [])
-            datas = ExternalDataSource.from_sources(module_path, inline_sources)
+            datas = ExternalDataSource.from_sources(module_path, sources)
             external_data.extend(datas)
             module_data.external_data.extend(datas)
 

--- a/src/checkers/firefoxchecker.py
+++ b/src/checkers/firefoxchecker.py
@@ -129,6 +129,7 @@ class FirefoxChecker(Checker):
         base_url = self.FIREFOX_ARCHIVE_BASE_URL.format(version=version)
 
         url = '{}SHA256SUMS'.format(base_url)
+        log.debug("Fetching %s", url)
         with urllib.request.urlopen(url) as response:
             sha256_table = response.read().decode()
 
@@ -155,11 +156,8 @@ class FirefoxChecker(Checker):
                 # Unfortunately, the release date in firefox_versions.json does not
                 # seem to be updated when a point release is made, so we have to get it
                 # from the files' last-modified date.
-                #
-                # TODO: just make a HEAD request to get the date and size, and fill in
-                # the SHA256sum that we already know.
-                info, _ = utils.get_extra_data_info_from_url(url)
-                info = info._replace(version=version)
+                info = utils.get_extra_data_info_from_head(url)
+                info = info._replace(url=url, checksum=sha256, version=version)
                 results[source_filename] = info
 
         return results

--- a/src/lib/externaldata.py
+++ b/src/lib/externaldata.py
@@ -133,6 +133,9 @@ class ExternalDataSource(ExternalData):
         external_data = []
 
         for source in sources:
+            if isinstance(source, str):
+                continue
+
             data = cls.from_source(source_path, source, sources)
             if data:
                 external_data.append(data)

--- a/src/lib/utils.py
+++ b/src/lib/utils.py
@@ -76,6 +76,25 @@ def get_timestamp_from_url(url):
     wait=wait_fixed(2),
     before_sleep=before_sleep_log(log, logging.DEBUG),
 )
+def get_extra_data_info_from_head(url):
+    request = urllib.request.Request(url, headers=HEADERS, method="HEAD")
+
+    with urllib.request.urlopen(request, timeout=TIMEOUT_SECONDS) as response:
+        real_url = response.geturl()
+        info = response.info()
+        size = int(info["Content-Length"])
+
+    return ExternalFile(
+        real_url, None, size, None, _extract_timestamp(info),
+    )
+
+
+@retry(
+    retry=retry_if_exception_type((ConnectionResetError, socket.timeout)),
+    stop=stop_after_attempt(3),
+    wait=wait_fixed(2),
+    before_sleep=before_sleep_log(log, logging.DEBUG),
+)
 def get_extra_data_info_from_url(url):
     request = urllib.request.Request(url, headers=HEADERS)
     data = None

--- a/src/lib/utils.py
+++ b/src/lib/utils.py
@@ -222,3 +222,10 @@ def dump_manifest(contents, manifest_path):
             _yaml.dump(contents, fp)
         else:
             json.dump(obj=contents, fp=fp, indent=4)
+
+
+def init_logging(level=logging.DEBUG):
+    logging.basicConfig(
+        level=level,
+        format="+ %(asctime)s %(levelname)7s %(name)s: %(message)s"
+    )

--- a/src/lib/utils.py
+++ b/src/lib/utils.py
@@ -97,10 +97,6 @@ def get_extra_data_info_from_head(url):
 )
 def get_extra_data_info_from_url(url):
     request = urllib.request.Request(url, headers=HEADERS)
-    data = None
-    checksum = ""
-    size = -1
-    real_url = None
 
     with urllib.request.urlopen(request, timeout=TIMEOUT_SECONDS) as response:
         real_url = response.geturl()

--- a/src/main.py
+++ b/src/main.py
@@ -31,7 +31,7 @@ import sys
 
 from github import Github
 
-from src.lib.utils import parse_github_url
+from src.lib.utils import parse_github_url, init_logging
 from src.lib.externaldata import ExternalData
 from src import checker
 
@@ -197,11 +197,7 @@ def main():
                         choices=types, default='all')
     args = parser.parse_args()
 
-    level = logging.DEBUG if args.verbose else logging.INFO
-    logging.basicConfig(
-        level=level,
-        format="+ %(asctime)s %(levelname)7s %(name)s: %(message)s"
-    )
+    init_logging(logging.DEBUG if args.verbose else logging.INFO)
 
     manifest_checker = checker.ManifestChecker(args.manifest)
     filter_type = ExternalData.TYPES.get(args.filter_type)

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -26,6 +26,7 @@ import tempfile
 
 from xml.dom import minidom
 
+from src.lib.utils import init_logging
 from src.lib.externaldata import ExternalData, Checker
 from src.checker import ManifestChecker
 
@@ -65,7 +66,7 @@ class UpdateEverythingChecker(Checker):
 
 class TestExternalDataChecker(unittest.TestCase):
     def setUp(self):
-        logging.basicConfig(level=logging.DEBUG)
+        init_logging()
 
     def test_check_filtered(self):
         # Use only the URLChecker which is fast so we don't have to wait a lot

--- a/tests/test_firefoxchecker.py
+++ b/tests/test_firefoxchecker.py
@@ -18,10 +18,10 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-import logging
 import os
 import unittest
 
+from src.lib.utils import init_logging
 from src.lib.externaldata import ExternalData
 from src.checker import ManifestChecker
 
@@ -30,7 +30,7 @@ TEST_MANIFEST = os.path.join(os.path.dirname(__file__), "org.mozilla.Firefox.jso
 
 class TestFirefoxChecker(unittest.TestCase):
     def setUp(self):
-        logging.basicConfig(level=logging.DEBUG)
+        init_logging()
 
     def test_check(self):
         checker = ManifestChecker(TEST_MANIFEST)

--- a/tests/test_flashchecker.py
+++ b/tests/test_flashchecker.py
@@ -18,10 +18,10 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-import logging
 import os
 import unittest
 
+from src.lib.utils import init_logging
 from src.checker import ManifestChecker
 
 TEST_MANIFEST = os.path.join(
@@ -32,7 +32,7 @@ TEST_MANIFEST = os.path.join(
 
 class TestFlashChecker(unittest.TestCase):
     def setUp(self):
-        logging.basicConfig(level=logging.DEBUG)
+        init_logging()
 
     def test_check(self):
         checker = ManifestChecker(TEST_MANIFEST)

--- a/tests/test_htmlchecker.py
+++ b/tests/test_htmlchecker.py
@@ -20,10 +20,10 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-import logging
 import os
 import unittest
 
+from src.lib.utils import init_logging
 from src.checker import ManifestChecker
 
 TEST_MANIFEST = os.path.join(
@@ -33,7 +33,7 @@ TEST_MANIFEST = os.path.join(
 
 class TestHTMLChecker(unittest.TestCase):
     def setUp(self):
-        logging.basicConfig(level=logging.DEBUG)
+        init_logging()
 
     def test_check(self):
         checker = ManifestChecker(TEST_MANIFEST)


### PR DESCRIPTION
This is currently crashing:

```
Traceback (most recent call last):
  File "/home/jenkins/workspace/check-flatpak-external-apps-pipeline/flatpak-external-data-checker", line 30, in <module>
    main()
  File "/home/jenkins/workspace/check-flatpak-external-apps-pipeline/src/main.py", line 213, in main
    changes = manifest_checker.update_manifests()
  File "/home/jenkins/workspace/check-flatpak-external-apps-pipeline/src/checker.py", line 230, in update_manifests
    self._update_manifest(path, datas, changes)
  File "/home/jenkins/workspace/check-flatpak-external-apps-pipeline/src/checker.py", line 202, in _update_manifest
    if data.new_version.version is not None:
AttributeError: 'NoneType' object has no attribute 'version'
```

It's a two-character fix but then I wanted to add a test, and then my test found another bug, and then I realised I could really easily make the Firefox check an order of magnitude faster (which makes running the tests marginally less painful).

Of course we hope that an official Firefox Flatpak will appear soon, but until then…