### PR TITLE
Allow to run tests on PR

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,5 +1,13 @@
 name: Run Tests
-on: push
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+    tags:
+      - "**"
+
 jobs:
   build:
     name: run-tests


### PR DESCRIPTION
Also restrict builds on push to master branch only. This avoids running CI twice on PR from another branch in the repo.