### PR TITLE
Support for nested modules

### DIFF
--- a/src/checker.py
+++ b/src/checker.py
@@ -67,9 +67,11 @@ class ManifestChecker:
         dump_manifest(contents, path)
 
     def _collect_external_data(self, path, json_data):
-        modules = json_data.get('modules', [])
+        modules = json_data.get('modules')
         if modules is None:
-            log.error("Failed to deserialize \"modules\" in %s", path)
+            return
+        elif not isinstance(modules, list):
+            log.warning("\"modules\" in %s is not a list", path)
             return
         for module in modules:
             if isinstance(module, str):

--- a/src/checker.py
+++ b/src/checker.py
@@ -69,8 +69,9 @@ class ManifestChecker:
     def _collect_external_data(self, path, json_data):
         for module in json_data.get('modules', []):
             if isinstance(module, str):
-                module_path = os.path.join(os.path.dirname(self._manifest),
+                module_path = os.path.join(os.path.dirname(path),
                                            module)
+                log.debug("Loading modules from %s", module_path)
 
                 try:
                     module = self._read_manifest(module_path)
@@ -92,7 +93,7 @@ class ManifestChecker:
             sources = module.get('sources', [])
             external_sources = [ source for source in sources if isinstance(source, str) ]
             for source in external_sources:
-                source_path = os.path.join(os.path.dirname(self._manifest), source)
+                source_path = os.path.join(os.path.dirname(path), source)
                 source_stat = os.stat(source_path)
                 if source_stat.st_size > 102400:
                     log.info("External source file is over 100KB, skipping: %s", source)
@@ -104,7 +105,7 @@ class ManifestChecker:
             module_data.external_data.extend(datas)
 
             for external_source in external_sources:
-                external_source_path = os.path.join(os.path.dirname(self._manifest),
+                external_source_path = os.path.join(os.path.dirname(path),
                                                     external_source)
                 external_source_data = self._read_manifest(external_source_path)
                 datas = ExternalDataSource.from_sources(external_source_path, external_source_data)

--- a/src/checker.py
+++ b/src/checker.py
@@ -87,6 +87,8 @@ class ManifestChecker:
             else:
                 module_path = path
 
+            self._collect_external_data(path=module_path, json_data=module)
+
             module_name = module.get('name')
             module_data = ModuleData(module_name, module_path, module)
 

--- a/src/checker.py
+++ b/src/checker.py
@@ -67,7 +67,11 @@ class ManifestChecker:
         dump_manifest(contents, path)
 
     def _collect_external_data(self, path, json_data):
-        for module in json_data.get('modules', []):
+        modules = json_data.get('modules', [])
+        if modules is None:
+            log.error("Failed to deserialize \"modules\" in %s", path)
+            return
+        for module in modules:
             if isinstance(module, str):
                 module_path = os.path.join(os.path.dirname(path),
                                            module)


### PR DESCRIPTION
Handle sub-modules of other modules, e.g. cases like this:
```yaml
id: tld.domain.App
modules:
  - name: the-app
    sources:
      - ...
    modules:
      - name: some-dependency
        sources:
          - ...
```
Currently sub-modules are ignored.