### PR TITLE
htmlchecker: Handle multiple matches

### DIFF
--- a/src/checkers/htmlchecker.py
+++ b/src/checkers/htmlchecker.py
@@ -41,12 +41,15 @@ def get_latest(checker_data, pattern_name, html):
     except KeyError:
         return None
 
-    m = pattern.search(html)
-    if m is None:
+    m = pattern.findall(html)
+    if not m:
         log.debug("%s %s did not match", pattern_name, pattern)
         return None
+    if len(m) > 1:
+        log.debug("%s %s matched multiple times, picking last match", pattern_name, pattern)
 
-    result = m.group(1)
+    result = m[-1]
+    assert isinstance(result, str)
     log.debug("%s %s matched: %s", pattern_name, pattern, result)
     return result
 

--- a/src/checkers/htmlchecker.py
+++ b/src/checkers/htmlchecker.py
@@ -42,7 +42,8 @@ def get_latest(checker_data, pattern_name, html):
     except KeyError:
         return None
 
-    assert pattern.groups == 1
+    if pattern.groups != 1:
+        raise ValueError(f"{pattern_name} {pattern} does not contain exactly 1 match group")
 
     m = pattern.findall(html)
     if not m:

--- a/src/checkers/htmlchecker.py
+++ b/src/checkers/htmlchecker.py
@@ -24,6 +24,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from string import Template
+from distutils.version import LooseVersion
 
 from src.lib import utils
 from src.lib.externaldata import ExternalData, Checker
@@ -47,11 +48,12 @@ def get_latest(checker_data, pattern_name, html):
     if not m:
         log.debug("%s %s did not match", pattern_name, pattern)
         return None
-    if len(m) > 1:
+    if len(m) == 1:
+        result = m[0]
+    else:
+        result = max(m, key=LooseVersion)
         log.debug("%s %s matched multiple times, picking last match", pattern_name, pattern)
 
-    result = m[-1]
-    assert isinstance(result, str)
     log.debug("%s %s matched: %s", pattern_name, pattern, result)
     return result
 

--- a/src/checkers/htmlchecker.py
+++ b/src/checkers/htmlchecker.py
@@ -51,8 +51,8 @@ def get_latest(checker_data, pattern_name, html):
     if len(m) == 1:
         result = m[0]
     else:
+        log.debug("%s %s matched multiple times, selecting latest", pattern_name, pattern)
         result = max(m, key=LooseVersion)
-        log.debug("%s %s matched multiple times, picking last match", pattern_name, pattern)
 
     log.debug("%s %s matched: %s", pattern_name, pattern, result)
     return result

--- a/src/checkers/htmlchecker.py
+++ b/src/checkers/htmlchecker.py
@@ -41,6 +41,8 @@ def get_latest(checker_data, pattern_name, html):
     except KeyError:
         return None
 
+    assert pattern.groups == 1
+
     m = pattern.findall(html)
     if not m:
         log.debug("%s %s did not match", pattern_name, pattern)


### PR DESCRIPTION
Single HTML page can list multiple program versions to download. In this case, pick the latest one, not the first match (which is likely to be the oldest version, given they are listed ascending).
This makes specifying exactly one group in pattern mandatory.