### PR TITLE
lib/externaldata: Look for arches in checker_data, default to x86_64

### DIFF
--- a/src/lib/externaldata.py
+++ b/src/lib/externaldata.py
@@ -113,14 +113,7 @@ class ExternalDataSource(ExternalData):
         sha256sum = source.get('sha256')
         size = source.get('size', -1)
         checker_data = source.get('x-checker-data', {})
-
-        # TODO: Switch to walrus operator when we switch to Python 3.8
-        if checker_data.get('arches'):
-            arches = checker_data.get('arches')
-        elif source.get('only-arches'):
-            arches = source.get('only-arches')
-        else:
-            arches = ["x86_64"]
+        arches = checker_data.get('arches') or source.get('only-arches') or ["x86_64"]
 
         super().__init__(
             data_type, source_path, sources, name, url, sha256sum, size, arches, checker_data,

--- a/src/lib/externaldata.py
+++ b/src/lib/externaldata.py
@@ -110,13 +110,22 @@ class ExternalDataSource(ExternalData):
             os.path.basename(url)
         )
 
-        sha256sum = source.get('sha256', None)
-        arches = source.get('only-arches', [])
+        sha256sum = source.get('sha256')
         size = source.get('size', -1)
-        checker_data = source.get('x-checker-data')
+        checker_data = source.get('x-checker-data', {})
+
+        # TODO: Switch to walrus operator when we switch to Python 3.8
+        if checker_data.get('arches'):
+            arches = checker_data.get('arches')
+        elif source.get('only-arches'):
+            arches = source.get('only-arches')
+        else:
+            arches = ["x86_64"]
+
         super().__init__(
             data_type, source_path, sources, name, url, sha256sum, size, arches, checker_data,
         )
+
         self.source = source
 
     @classmethod

--- a/tests/org.externaldatachecker.Manifest.json
+++ b/tests/org.externaldatachecker.Manifest.json
@@ -24,7 +24,6 @@
                 {
                     "type": "extra-data",
                     "filename": "flatpak",
-                    "only-arches": ["i386"],
                     "url": "http://ftp.de.debian.org/some-broken-debian-pkg.deb",
                     "sha256": "000000000000000000000000000000000000000000000000000000000000000000",
                     "size": 1234567,
@@ -33,7 +32,8 @@
                         "package-name": "flatpak",
                         "root": "https://deb.debian.org/debian/",
                         "dist": "stable",
-                        "component": "main"
+                        "component": "main",
+                        "arches": ["i386"]
                     }
                 },
                 {
@@ -54,7 +54,6 @@
 		{
                     "type": "extra-data",
                     "filename": "flatpak",
-                    "only-arches": ["x86_64"],
                     "url": "http://debian.org",
                     "sha256": "just-a-valid-url-0000000000000000000000000000000000000000000000000",
                     "size": 1234567,


### PR DESCRIPTION
Flathub apps often limit target architectures with only-arches in
flathub.json, making the manifest counterpart redundant. Look for
arches in x-checker-data first, then in only-arches, finally default
to x86_64.