### PR TITLE
ci: don't fail if Coveralls token is missing

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,3 +20,4 @@ jobs:
         run: docker run -v $PWD:/opt -w /opt flatpak-external-data-checker python3-coverage run -m unittest discover --verbose --buffer
       - name: Submit code coverage to Coveralls.io
         run: docker run --env COVERALLS_REPO_TOKEN=${{ secrets.COVERALLS_REPO_TOKEN }}  -v $PWD:/opt -w /opt flatpak-external-data-checker coveralls
+        continue-on-error: true


### PR DESCRIPTION
This happens when a PR is submitted by someone without write access to
the repo.