### PR TITLE
Add metainfo

### DIFF
--- a/data/org.flathub.flatpak-external-data-checker.metainfo.xml
+++ b/data/org.flathub.flatpak-external-data-checker.metainfo.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="console-application">
+  <id>org.flathub.flatpak-external-data-checker</id>
+  <name>Flatpak External Data Checker</name>
+  <summary>A tool for checking if the external data used in Flatpak manifests is still up to date</summary>
+  <url type="homepage">https://github.com/flathub/flatpak-external-data-checker</url>
+  <url type="bugtracker">https://github.com/flathub/flatpak-external-data-checker/issues</url>
+  <description>
+    <p>This is a tool for checking for outdated or broken links of external data in Flatpak manifests.</p>
+  </description>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-2.0</project_license>
+  <content_rating type="oars-1.1"/>
+</component>


### PR DESCRIPTION
This might be useful for packaging flatpak-external-data-checker, e.g. on Flathub itself.