### PR TITLE
appdata: switch to defusedxml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update \
       gir1.2-json-1.0 \
       python3-apt \
       python3-coverage \
+      python3-defusedxml \
       python3-gi \
       python3-github \
       python3-pip \

--- a/src/lib/appdata.py
+++ b/src/lib/appdata.py
@@ -24,7 +24,7 @@ missing.
 """
 
 from io import StringIO
-from xml.sax import make_parser
+from defusedxml.sax import make_parser
 from xml.sax.handler import property_lexical_handler
 from xml.sax.saxutils import XMLFilterBase, XMLGenerator
 


### PR DESCRIPTION
The [xml.sax][] documentation begins with a dire warning:

> The xml.sax module is not secure against maliciously constructed data.
> If you need to parse untrusted or unauthenticated data see [XML
> vulnerabilities][].

The linked page shows that xml.sax is vulnerable to, at least, two
entity expansion attacks, and recommends defusedxml as a drop-in
replacement.

While the XML handled by this library is not exactly *untrusted*, it is
not exactly *trusted* either. We don't expect appdata files to be in the
business of defining new XML entities, so drop in defusedxml to prevent
this.

Thanks to Seppo Yli-Olli for pointing out this issue.

[xml.sax]: https://docs.python.org/3/library/xml.sax.html
[XML vulnerabilities]: https://docs.python.org/3/library/xml.html#xml-vulnerabilities