### PR TITLE
Revert "main: Use pygit2 to determine current branch"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,6 @@ RUN apt-get update \
       python3-gi \
       python3-github \
       python3-pip \
-      python3-pygit2 \
       python3-ruamel.yaml \
       python3-setuptools \
       python3-tenacity \

--- a/src/main.py
+++ b/src/main.py
@@ -30,7 +30,6 @@ import subprocess
 import sys
 
 from github import Github
-from pygit2 import Repository
 
 from src.lib.utils import parse_github_url, init_logging
 from src.lib.externaldata import ExternalData
@@ -159,9 +158,7 @@ def open_pr(subject, body, branch):
     else:
         check_call(("git", "remote", "set-url", remote, remote_url))
 
-    repo = Repository('.')
-    base = repo.head.shorthand
-
+    base = "master"
     head = "{}:{}".format(repo.owner.login, branch)
     pr_message = ((body or "") + "\n\n" + DISCLAIMER).strip()
     # Include closed PRs – if the maintainer has closed our last PR, we don't want to


### PR DESCRIPTION
Reverts flathub/flatpak-external-data-checker#68.

```
+ 2020-01-07 17:34:43,410   DEBUG src.main: $ git remote set-url origin https://****:x-oauth-basic@github.com/endlessm/firefox-flatpak
Traceback (most recent call last):
  File "/home/jenkins/workspace/check-flatpak-external-apps-pipeline/flatpak-external-data-checker", line 30, in <module>
    main()
  File "/home/jenkins/workspace/check-flatpak-external-apps-pipeline/src/main.py", line 224, in main
    open_pr(subject, body, branch)
  File "/home/jenkins/workspace/check-flatpak-external-apps-pipeline/src/main.py", line 165, in open_pr
    head = "{}:{}".format(repo.owner.login, branch)
AttributeError: 'Repository' object has no attribute 'owner'
```

This is because the new assignment to `repo` shadows the previous assignment.