### PR TITLE
urlchecker: Strip query string from redirect target

### DIFF
--- a/tests/org.externaldatachecker.Manifest.json
+++ b/tests/org.externaldatachecker.Manifest.json
@@ -74,8 +74,8 @@
                     "size": 1234567,
                     "x-checker-data": {
                         "type": "rotating-url",
-                        "url": "https://httpbin.org/redirect-to?url=https%3A%2F%2Fhttpbin.org%2Fimage%2Fjpeg%3Fversion=1.2.3.4&status_code=302",
-                        "pattern": ".*?version=([0-9.]+)$"
+                        "url": "https://httpbin.org/redirect-to?url=https%3A%2F%2Fhttpbin.org%2Fbase64%2F4puE&status_code=302",
+                        "pattern": ".*base(..).*"
                     }
                 },
                 {

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -303,10 +303,8 @@ modules:
 
         dropbox = self._find_by_filename(ext_data, "dropbox.tgz")
         self.assertIsNotNone(dropbox)
-        self.assertEqual(dropbox.new_version.version, "1.2.3.4")
-        self.assertEqual(
-            dropbox.new_version.url, "https://httpbin.org/image/jpeg?version=1.2.3.4",
-        )
+        self.assertEqual(dropbox.new_version.version, "64")
+        self.assertEqual(dropbox.new_version.url, "https://httpbin.org/base64/4puE")
 
         # this URL is a redirect, but since it is not a rotating-url the URL
         # should not be updated.

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -19,7 +19,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 import unittest
 
-from src.lib.utils import parse_github_url
+from src.lib.utils import parse_github_url, strip_query
 
 
 class TestParseGitHubUrl(unittest.TestCase):
@@ -38,6 +38,18 @@ class TestParseGitHubUrl(unittest.TestCase):
     def test_https_with_auth(self):
         url = "https://acce55ed:x-oauth-basic@github.com/endlessm/eos-google-chrome-app"
         self.assertEqual(parse_github_url(url), "endlessm/eos-google-chrome-app")
+
+
+class TestStripQuery(unittest.TestCase):
+    def test_strip_query(self):
+        url = "https://d11yldzmag5yn.cloudfront.net/prod/3.5.372466.0322/zoom_x86_64.tar.xz?_x_zm_rtaid=muDd1uOqSZ-xUScZF698QQ.1585134521724.21e5ab14908b2121f5ed53882df91cb9&_x_zm_rhtaid=732"  # noqa: E501
+        expected = "https://d11yldzmag5yn.cloudfront.net/prod/3.5.372466.0322/zoom_x86_64.tar.xz"
+        self.assertEqual(strip_query(url), expected)
+
+    def test_preserve_auth(self):
+        url = "https://user:pass@example.com/"
+        expected = url
+        self.assertEqual(strip_query(url), expected)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This script is spamming the Zoom repo with patches like this:

```patch
-"url": "https://d11yldzmag5yn.cloudfront.net/prod/3.5.372466.0322/zoom_x86_64.tar.xz",
+"url": "https://d11yldzmag5yn.cloudfront.net/prod/3.5.372466.0322/zoom_x86_64.tar.xz?_x_zm_rtaid=muDd1uOqSZ-xUScZF698QQ.1585134521724.21e5ab14908b2121f5ed53882df91cb9&_x_zm_rhtaid=732",
```

This appears to be a marketing tag, and as such changes every time the
bot scrapes the homepage.

To avoid this, strip all query strings when following a rotating-url.

In principle, there might be situations where the query string has to be
preserved, so this would need to be configurable. In practice, I expect
that only the test case changed in this patch will be affected.

Fixes #78