### PR TITLE
Revert "debianrepochecker: strip Debian revision from package"

### DIFF
--- a/src/checkers/debianrepochecker.py
+++ b/src/checkers/debianrepochecker.py
@@ -117,19 +117,11 @@ class DebianRepoChecker(Checker):
         with self._load_repo(root, dist, component, arch) as cache:
             package = cache[package_name]
             candidate = package.candidate
-            # http://www.fifi.org/doc/debian-policy/policy.html/ch-versions.html
-            #
-            # The version number format is: [epoch:]upstream_version[-debian_revision]
-            #
-            # The package management system will break the version number apart at the
-            # last hyphen in the string (if there is one) to determine the
-            # upstream_version and debian_revision.
-            upstream_version = candidate.version.rsplit("-", 1)[0]
             new_version = ExternalFile(
                 candidate.uri,
                 candidate.sha256,
                 candidate.size,
-                upstream_version,
+                candidate.version,
                 timestamp=_get_timestamp_for_candidate(candidate),
             )
 


### PR DESCRIPTION
This reverts commit fe82ed9d6a960fe06ead892d0a4d571f26dafd0c.

My only justification for that behaviour was “I think the -1 is ugly”.
Over on https://github.com/flathub/com.visualstudio.code.insiders/pull/1
we have a case where the package revision matters, so let's leave it in
place.

(Of course it could be made configurable but I'd prefer to keep this
simple.)