### PR TITLE
Only strip query parameters beginning with underscore

### DIFF
--- a/src/lib/utils.py
+++ b/src/lib/utils.py
@@ -70,11 +70,16 @@ def _extract_timestamp(info):
 
 
 def strip_query(url):
-    """Strips the query string from the given URL, if any."""
+    """Sanitizes the query string from the given URL, if any. Parameters whose
+    names begin with an underscore are assumed to be tracking identifiers and
+    are removed."""
     parts = urllib.parse.urlparse(url)
     if not parts.query:
         return url
-    stripped = urllib.parse.urlunparse(parts._replace(query=""))
+    qsl = urllib.parse.parse_qsl(parts.query)
+    qsl_stripped = [(k, v) for (k, v) in qsl if not k.startswith("_")]
+    query_stripped = urllib.parse.urlencode(qsl_stripped)
+    stripped = urllib.parse.urlunparse(parts._replace(query=query_stripped))
     log.debug("Normalised %s to %s", url, stripped)
     return stripped
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -46,6 +46,11 @@ class TestStripQuery(unittest.TestCase):
         expected = "https://d11yldzmag5yn.cloudfront.net/prod/3.5.372466.0322/zoom_x86_64.tar.xz"
         self.assertEqual(strip_query(url), expected)
 
+    def test_preserve_nice_query(self):
+        url = "https://dl2.tlauncher.org/f.php?f=files%2FTLauncher-2.69.zip"
+        expected = url
+        self.assertEqual(strip_query(url), expected)
+
     def test_preserve_auth(self):
         url = "https://user:pass@example.com/"
         expected = url


### PR DESCRIPTION
This behaviour was introduced to strip tracking junk from Zoom URLs but
caused problems in a case where query parameters are necessary.

Be a little less ruthless by only stripping parameters whose names begin
with underscores, as a heuristic for "is tracking-ish".

Fixes #83