### PR TITLE
Add JSON checker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update \
       python3-toml \
       python3-pyelftools \
       squashfs-tools \
+      jq \
   && apt-get clean \
   && rmdir /var/cache/apt/archives/partial
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,25 @@ the retrieved version:
 }
 ```
 
+### JSON checker
+
+The JSON checker allows using [jq](https://stedolan.github.io/jq/) to query
+JSON data with arbitrary schema to get version and download url.
+
+To use the **JSONChecker**, specify JSON data URL, version query and url query
+(you can use `$version` variable got from the version query in url query):
+
+```json
+{
+    "type": "json",
+    "url": "https://api.github.com/repos/stedolan/jq/releases/latest",
+    "version-query": ".tag_name | sub(\"^jq-\"; \"\")",
+    "url-query": ".assets[] | select(.name==\"jq-\" + $version + \".tar.gz\") | .browser_download_url"
+}
+```
+
+See the [jq manual](https://stedolan.github.io/jq/manual/) for complete information about writing queries.
+
 ### Debian repo checker
 
 For the **DebianRepoChecker**, which deals only with deb packages, it

--- a/src/checkers/__init__.py
+++ b/src/checkers/__init__.py
@@ -1,5 +1,6 @@
 from .debianrepochecker import DebianRepoChecker
 from .firefoxchecker import FirefoxChecker
+from .jsonchecker import JSONChecker
 from .urlchecker import URLChecker
 from .htmlchecker import HTMLChecker
 from .jetbrainschecker import JetBrainsChecker
@@ -18,5 +19,6 @@ ALL_CHECKERS = [
     SnapcraftChecker,
     AnityaChecker,
     RustChecker,
+    JSONChecker,
     URLChecker,  # leave this last
 ]

--- a/src/checkers/jsonchecker.py
+++ b/src/checkers/jsonchecker.py
@@ -1,0 +1,62 @@
+import logging
+import urllib.request
+import os
+import subprocess
+
+from src.lib import utils
+from .htmlchecker import HTMLChecker
+
+log = logging.getLogger(__name__)
+
+
+def query_json(query, data, variables=None):
+    typecheck_q = (
+        '.|type as $rt | if $rt=="string" or $rt=="number" then . else error($rt) end'
+    )
+
+    var_args = []
+    if variables is not None:
+        for var_name, var_value in variables.items():
+            var_args += ["--arg", var_name, var_value]
+
+    jq_cmd = ["jq"] + var_args + ["-r", "-e", f"( {query} ) | ( {typecheck_q} )"]
+    if utils.check_bwrap():
+        jq_cmd = utils.wrap_in_bwrap(jq_cmd, bwrap_args=["--die-with-parent"])
+
+    jq_proc = subprocess.run(
+        jq_cmd,
+        check=True,
+        stdout=subprocess.PIPE,
+        input=data,
+        timeout=10,
+        env=utils.clear_env(os.environ),
+    )
+    return jq_proc.stdout.decode().strip()
+
+
+class JSONChecker(HTMLChecker):
+    def _should_check(self, external_data):
+        return external_data.checker_data.get("type") == "json"
+
+    def check(self, external_data):
+        if not self._should_check(external_data):
+            log.debug("%s is not a json type ext data", external_data.filename)
+            return
+
+        json_url = external_data.checker_data["url"]
+        url_query = external_data.checker_data["url-query"]
+        version_query = external_data.checker_data["version-query"]
+
+        log.debug("Getting JSON from %s", json_url)
+        with urllib.request.urlopen(json_url) as resp:
+            json_data = resp.read()
+
+        latest_version = query_json(version_query, json_data)
+        latest_url = query_json(url_query, json_data, {"version": latest_version})
+
+        if not latest_version or not latest_url:
+            return
+
+        self._update_version(
+            external_data, latest_version, latest_url, follow_redirects=False
+        )

--- a/tests/io.github.stedolan.jq.yml
+++ b/tests/io.github.stedolan.jq.yml
@@ -1,0 +1,26 @@
+id: io.github.stedolan.jq
+modules:
+  - name: jq
+    sources:
+      - type: archive
+        url: https://github.com/stedolan/jq/releases/download/jq-1.4/jq-1.4.tar.gz
+        sha256: "0000000000000000000000000000000000000000000000000000000000000000"
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/stedolan/jq/releases/latest
+          version-query: '.tag_name | sub("^jq-"; "")'
+          url-query: '.assets[] | select(.name=="jq-" + $version + ".tar.gz") | .browser_download_url'
+    modules:
+
+      - name: oniguruma
+        buildsystem: cmake-ninja
+        sources:
+          - type: archive
+            archive-type: tar-gzip
+            url: https://api.github.com/repos/kkos/oniguruma/tarball/v6.9.4
+            sha256: "0000000000000000000000000000000000000000000000000000000000000000"
+            x-checker-data:
+              type: json
+              url: https://api.github.com/repos/kkos/oniguruma/releases/latest
+              version-query: '.tag_name | sub("^v"; "")'
+              url-query: '.tarball_url'

--- a/tests/test_jsonchecker.py
+++ b/tests/test_jsonchecker.py
@@ -1,0 +1,40 @@
+import os
+import unittest
+
+from src.checker import ManifestChecker
+from src.lib.utils import init_logging
+
+TEST_MANIFEST = os.path.join(os.path.dirname(__file__), "io.github.stedolan.jq.yml")
+
+
+class TestJSONChecker(unittest.TestCase):
+    def setUp(self):
+        init_logging()
+
+    def test_check(self):
+        checker = ManifestChecker(TEST_MANIFEST)
+        ext_data = checker.check()
+
+        self.assertEqual(len(ext_data), 2)
+        for data in ext_data:
+            self.assertIsNotNone(data)
+            self.assertIsNotNone(data.new_version)
+            if data.filename == "v6.9.4":
+                url_re = (
+                    r"^https://api.github.com/repos/kkos/oniguruma/tarball/v[0-9\.\w]+$"
+                )
+            elif data.filename == "jq-1.4.tar.gz":
+                url_re = r"^https://github.com/stedolan/jq/releases/download/jq-[0-9\.\w]+/jq-[0-9\.\w]+\.tar.gz$"
+            else:
+                url_re = None
+            self.assertIsNotNone(url_re)
+            self.assertNotEqual(data.current_version.url, data.new_version.url)
+            self.assertRegex(data.new_version.url, url_re)
+            self.assertIsInstance(data.new_version.size, int)
+            self.assertGreater(data.new_version.size, 0)
+            self.assertIsNotNone(data.new_version.checksum)
+            self.assertIsInstance(data.new_version.checksum, str)
+            self.assertNotEqual(
+                data.new_version.checksum,
+                "0000000000000000000000000000000000000000000000000000000000000000",
+            )


### PR DESCRIPTION
This is just like HTML checker, but uses `jq` queries on json urls instead of  regular expressions on html pages.

Usage example (for telegram-desktop, source from github releases in attachment):
```json
"type": "archive",
"url": "https://github.com/telegramdesktop/tdesktop/releases/download/v2.3.2/tdesktop-2.3.2-full.tar.gz",
"sha256": "292631bcac4b30f778879ecd2cebf4c6f569ab5be01230c8e62b924b4211a259",
"x-checker-data": {
    "type": "json",
    "url": "https://api.github.com/repos/telegramdesktop/tdesktop/releases/latest",
    "version-query": ".tag_name",
    "url-query": ".assets[] | select(.label==\"Source code (tar.gz, full)\") | .browser_download_url"
}
```

**Warning**:  running queries from untrusted sources poses a security risk. We must either sanitize query before passing it to `jq`, or run the whole thing in a sandbox.
Current implementation executes `jq` in `bwrap` sandbox, yet I'm not sure if this is enough.