### PR TITLE
Adds GNOME Checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,12 +214,20 @@ Both the version number and the download URL will be gathered from  [download.gn
 "x-checker-data": {
     "type": "gnome",
     "name": "PACKAGE-NAME",
-    "skip-unstable": true
 }
 ```
 
-where `PACKAGE-NAME` is set according to the name in [download.gnome.org/sources](https://download.gnome.org/sources).
-`skip-unstable` is optional and when set to `true` it will ignore unstable releases, e.g. "3.37.1" or "40.rc.2".
+where `PACKAGE-NAME` is set according to the package name as seen in [download.gnome.org/sources](https://download.gnome.org/sources).
+
+By default the checker skips unstable releases, e.g. releases tagged as "3.37.1" or "40.rc.2". To disable this behavior use
+
+```json
+"x-checker-data": {
+    "type": "gnome",
+    "name": "PACKAGE-NAME",
+    "skip-unstable": false
+}
+```
 
 ## License and Copyright
 

--- a/README.md
+++ b/README.md
@@ -206,6 +206,20 @@ for [Snapcraft](https://snapcraft.io/) packages:
 }
 ```
 
+#### GNOME checker
+
+Both the version number and the download URL will be gathered from  [download.gnome.org](https://download.gnome.org/). The format is:
+
+```json
+"x-checker-data": {
+    "type": "gnome",
+    "name": "PACKAGE-NAME",
+    "skip-unstable": true
+}
+```
+
+where `PACKAGE-NAME` is set according to the name in [download.gnome.org/sources](https://download.gnome.org/sources).
+`skip-unstable` is optional and when set to `true` it will ignore unstable releases, e.g. "3.37.1" or "40.rc.2".
 
 ## License and Copyright
 

--- a/src/checkers/__init__.py
+++ b/src/checkers/__init__.py
@@ -5,6 +5,7 @@ from .urlchecker import URLChecker
 from .htmlchecker import HTMLChecker
 from .jetbrainschecker import JetBrainsChecker
 from .snapcraftchecker import SnapcraftChecker
+from .gnomechecker import GNOMEChecker
 
 
 # For each ExternalData, checkers are run in the order listed here, stopping once data.state is
@@ -16,5 +17,6 @@ ALL_CHECKERS = [
     HTMLChecker,
     JetBrainsChecker,
     SnapcraftChecker,
+    GNOMEChecker,
     URLChecker,  # leave this last
 ]

--- a/src/checkers/gnomechecker.py
+++ b/src/checkers/gnomechecker.py
@@ -1,0 +1,120 @@
+# GNOME Checker: A checker to see if the url is pointing to the latest Release.
+#
+# Consult the README for information on how to use this checker.
+#
+# Copyright © 2020 Maximiliano Sandoval <msandova@protonmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+import logging
+import re
+import urllib.error
+import urllib.parse
+import urllib.request
+from distutils.version import LooseVersion
+
+from src.lib import utils
+from src.lib.externaldata import ExternalData, Checker
+
+log = logging.getLogger(__name__)
+
+
+def get_latest(package_name):
+    """
+    If checker_data contains a "name", matches 'cache.json' against it and
+    returns the latest version without and with its minor release
+    """
+    url = "https://download.gnome.org/sources/{}/cache.json".format(
+        package_name)
+
+    try:
+        pattern = re.compile(
+            "([\\d.]+\\d)/{}-([\\d.]+\\d).tar.xz".format(package_name))
+    except KeyError:
+        return None
+
+    if pattern.groups != 2:
+        raise ValueError(
+            f"{pattern} does not contain exactly 2 match group"
+        )
+
+    resp = urllib.request.urlopen(url)
+    html = resp.read().decode()
+
+    m = pattern.findall(html)
+    if not m:
+        log.debug("%s did not match", pattern)
+        return None
+    if len(m) == 1:
+        result = m[0]
+    else:
+        log.debug(
+            "%s matched multiple times, selecting latest", pattern
+        )
+        versions = [x[0] for x in m]
+        short_versions = [x[1] for x in m]
+        result = (
+            max(versions, key=LooseVersion),
+            max(short_versions, key=LooseVersion)
+        )
+
+    log.debug("%s matched: %s",  pattern, result[1])
+    return result
+
+
+class GNOMEChecker(Checker):
+    def _should_check(self, external_data):
+        return external_data.checker_data.get("type") == "gnome"
+
+    def check(self, external_data):
+
+        if not self._should_check(external_data):
+            log.debug("%s is not a GNOME type ext data",
+                      external_data.filename)
+            return
+        name = external_data.checker_data["name"]
+        url = "https://download.gnome.org/sources/{}/cache.json".format(name)
+        log.debug("Getting extra data info from %s; may take a while", url)
+
+        latest_version_short, latest_version = get_latest(name)
+        latest_url = "https://download.gnome.org/sources/{}/{}/{}-{}.tar.xz".format(
+            name, latest_version_short, name, latest_version
+            )
+
+        if not latest_version:
+            log.warning(
+                "%s had no available version information",
+                external_data.filename
+            )
+
+        if not latest_version or not latest_url:
+            return
+
+        assert latest_version is not None
+
+        try:
+            new_version, _ = utils.get_extra_data_info_from_url(latest_url)
+        except urllib.error.HTTPError as e:
+            log.warning("%s returned %s", latest_url, e)
+            external_data.state = ExternalData.State.BROKEN
+        except Exception:
+            log.exception("Unexpected exception while checking %s", latest_url)
+            external_data.state = ExternalData.State.BROKEN
+        else:
+            external_data.state = ExternalData.State.VALID
+            new_version = new_version._replace(version=latest_version)
+            new_version = new_version._replace(url=latest_url)
+            if not external_data.current_version.matches(new_version):
+                external_data.new_version = new_version

--- a/src/checkers/gnomechecker.py
+++ b/src/checkers/gnomechecker.py
@@ -105,6 +105,9 @@ class GNOMEChecker(Checker):
     def check(self, external_data):
 
         skip_unstable = external_data.checker_data.get("skip-unstable")
+        if skip_unstable is None:
+            skip_unstable = True
+
         if not self._should_check(external_data):
             log.debug("%s is not a GNOME type ext data",
                       external_data.filename)

--- a/tests/org.gnome.baobab.json
+++ b/tests/org.gnome.baobab.json
@@ -6,17 +6,17 @@
     "command" : "baobab",
     "modules" : [
         {
-            "name" : "libhandy",
-            "filename" : "libhandy-0.81.0.tar.xz",
+            "name" : "GnomeHello",
+            "filename" : "alleyoop-0.9.8.tar.xz",
             "buildsystem" : "meson",
             "sources" : [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/libhandy/0.81/libhandy-0.81.0.tar.xz",
-                    "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "url": "https://download.gnome.org/sources/alleyoop/0.9/alleyoop-0.9.8.tar.xz",
+                    "sha256sum": "0000000000000000000000000000000000000000000000000000000000000000",
                     "x-checker-data": {
                         "type": "gnome",
-                        "name": "libhandy"
+                        "name": "alleyoop"
                     }
                 }
             ]

--- a/tests/org.gnome.baobab.json
+++ b/tests/org.gnome.baobab.json
@@ -32,7 +32,8 @@
                     "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
                     "x-checker-data": {
                         "type": "gnome",
-                        "name": "baobab"
+                        "name": "baobab",
+                        "skip-unstable": true
                     }
                 }
             ]

--- a/tests/org.gnome.baobab.json
+++ b/tests/org.gnome.baobab.json
@@ -1,0 +1,41 @@
+{
+    "app-id" : "org.gnome.baobab",
+    "runtime" : "org.gnome.Platform",
+    "runtime-version" : "3.38",
+    "sdk" : "org.gnome.Sdk",
+    "command" : "baobab",
+    "modules" : [
+        {
+            "name" : "libhandy",
+            "filename" : "libhandy-0.81.0.tar.xz",
+            "buildsystem" : "meson",
+            "sources" : [
+                {
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/libhandy/0.81/libhandy-0.81.0.tar.xz",
+                    "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "x-checker-data": {
+                        "type": "gnome",
+                        "name": "libhandy"
+                    }
+                }
+            ]
+        },
+        {
+            "name" : "baobab",
+            "filename" : "baobab-3.34.0.tar.xz",
+            "buildsystem" : "meson",
+            "sources" : [
+                {
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/baobab/3.34/baobab-3.34.0.tar.xz",
+                    "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "x-checker-data": {
+                        "type": "gnome",
+                        "name": "baobab"
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/tests/test_gnomechecker.py
+++ b/tests/test_gnomechecker.py
@@ -70,7 +70,6 @@ class TestGNOMEChecker(unittest.TestCase):
         self.assertGreater(data.new_version.size, 0)
         self.assertIsNotNone(data.new_version.checksum)
         self.assertIsInstance(data.new_version.checksum, str)
-        print(data.new_version.url)
         self.assertEqual(
             data.new_version.checksum,
             "a9398582f47b7d729205d6eac0c068fef35aaf249fdd57eea3724f8518d26699",

--- a/tests/test_gnomechecker.py
+++ b/tests/test_gnomechecker.py
@@ -58,13 +58,13 @@ class TestGNOMEChecker(unittest.TestCase):
         checker = ManifestChecker(TEST_MANIFEST)
         ext_data = checker.check()
 
-        data = self._find_by_filename(ext_data, "libhandy-0.81.0.tar.xz")
+        data = self._find_by_filename(ext_data, "alleyoop-0.9.8.tar.xz")
 
         self.assertIsNotNone(data)
-        self.assertEqual(data.filename, "libhandy-0.81.0.tar.xz")
+        self.assertEqual(data.filename, "alleyoop-0.9.8.tar.xz")
         self.assertIsNotNone(data.new_version)
         self.assertEqual(
-            data.new_version.version, "1.0.0",
+            data.new_version.version, "0.9.8",
         )
         self.assertIsInstance(data.new_version.size, int)
         self.assertGreater(data.new_version.size, 0)
@@ -72,7 +72,7 @@ class TestGNOMEChecker(unittest.TestCase):
         self.assertIsInstance(data.new_version.checksum, str)
         self.assertEqual(
             data.new_version.checksum,
-            "a9398582f47b7d729205d6eac0c068fef35aaf249fdd57eea3724f8518d26699",
+            "adaa432fbbdccdb07751b2a5b8f0159a31d8d8f3d27503374a96122778163ff1",
         )
 
     def _find_by_filename(self, ext_data, filename):

--- a/tests/test_gnomechecker.py
+++ b/tests/test_gnomechecker.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+# Copyright © 2020 Maximiliano Sandoval <msandova@protonmail.com>
+#
+# Authors:
+#       Maximiliano Sandoval <msandova@protonmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+import os
+import unittest
+
+from src.lib.utils import init_logging
+from src.checker import ManifestChecker
+
+TEST_MANIFEST = os.path.join(
+    os.path.dirname(__file__), "org.gnome.baobab.json"
+)
+
+class TestGNOMEChecker(unittest.TestCase):
+    def setUp(self):
+        init_logging()
+
+    def test_check(self):
+        checker = ManifestChecker(TEST_MANIFEST)
+        ext_data = checker.check()
+
+        data = self._find_by_filename(ext_data, "baobab-3.34.0.tar.xz")
+
+        self.assertIsNotNone(data)
+        self.assertEqual(data.filename, "baobab-3.34.0.tar.xz")
+        self.assertIsNotNone(data.new_version)
+        self.assertRegex(
+            data.new_version.url,
+            r"^https://download\.gnome\.org/sources/baobab/.+/baobab-.+\.tar\.xz$",  # noqa: E501
+        )
+        self.assertIsInstance(data.new_version.size, int)
+        self.assertGreater(data.new_version.size, 0)
+        self.assertIsNotNone(data.new_version.checksum)
+        self.assertIsInstance(data.new_version.checksum, str)
+        self.assertNotEqual(
+            data.new_version.checksum,
+            "0000000000000000000000000000000000000000000000000000000000000000",
+        )
+
+    def test_check_library(self):
+        checker = ManifestChecker(TEST_MANIFEST)
+        ext_data = checker.check()
+
+        data = self._find_by_filename(ext_data, "libhandy-0.81.0.tar.xz")
+
+        self.assertIsNotNone(data)
+        self.assertEqual(data.filename, "libhandy-0.81.0.tar.xz")
+        self.assertIsNotNone(data.new_version)
+        self.assertEqual(
+            data.new_version.version, "1.0.0",
+        )
+        self.assertIsInstance(data.new_version.size, int)
+        self.assertGreater(data.new_version.size, 0)
+        self.assertIsNotNone(data.new_version.checksum)
+        self.assertIsInstance(data.new_version.checksum, str)
+        print(data.new_version.url)
+        self.assertEqual(
+            data.new_version.checksum,
+            "a9398582f47b7d729205d6eac0c068fef35aaf249fdd57eea3724f8518d26699",
+        )
+
+    def _find_by_filename(self, ext_data, filename):
+        for data in ext_data:
+            if data.filename == filename:
+                return data
+        else:
+            return None
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a checker for gnome, see #91. Format should be
```json
                    "x-checker-data": {
                        "type": "gnome",
                        "name": "baobab"
                    }
```
TODO:

- [x] Update README
- [ ] Unit test for unstable package
- [x] Unit test for package already using latest
- [x] Use an example for the test which won't be updated, unlike libhandy
- [x] Skip unstable releases, e.g. `3.37.x` and `40.alpha`
- [x] Set `skip-unstable` by default
- ~~Fix CI~~ See #90 