### PR TITLE
Add anitya (release-monitoring) checker

### DIFF
--- a/src/checkers/__init__.py
+++ b/src/checkers/__init__.py
@@ -5,6 +5,7 @@ from .urlchecker import URLChecker
 from .htmlchecker import HTMLChecker
 from .jetbrainschecker import JetBrainsChecker
 from .snapcraftchecker import SnapcraftChecker
+from .anityachecker import AnityaChecker
 
 
 # For each ExternalData, checkers are run in the order listed here, stopping once data.state is
@@ -16,5 +17,6 @@ ALL_CHECKERS = [
     HTMLChecker,
     JetBrainsChecker,
     SnapcraftChecker,
+    AnityaChecker,
     URLChecker,  # leave this last
 ]

--- a/src/checkers/anityachecker.py
+++ b/src/checkers/anityachecker.py
@@ -1,0 +1,47 @@
+import logging
+import urllib.request
+import urllib.parse
+import json
+from string import Template
+
+from .htmlchecker import HTMLChecker
+
+log = logging.getLogger(__name__)
+
+
+class AnityaChecker(HTMLChecker):
+    def _should_check(self, external_data):
+        return external_data.checker_data.get("type") == "anitya"
+
+    def check(self, external_data):
+        if not self._should_check(external_data):
+            log.debug("%s is not a anitya type ext data", external_data.filename)
+            return
+
+        instance_url = external_data.checker_data.get(
+            "baseurl", "https://release-monitoring.org"
+        )
+        try:
+            project_id = external_data.checker_data["project-id"]
+            url_template = external_data.checker_data["url-template"]
+        except KeyError as e:
+            log.error("Missing required key: %s", e)
+            return
+        if not isinstance(project_id, int):
+            log.error("Invalid type `%s` for project id", type(project_id).__name__)
+            return
+
+        project_url = urllib.parse.urljoin(instance_url, f"/api/project/{project_id}/")
+        log.debug("Getting JSON from %s", project_url)
+        with urllib.request.urlopen(project_url) as resp:
+            result = json.load(resp)
+
+        latest_version = result.get("version")
+        if not latest_version:
+            log.error("%s had no available version information", external_data.filename)
+            return
+        latest_url = Template(url_template).substitute(version=latest_version)
+
+        self._update_version(
+            external_data, latest_version, latest_url, follow_redirects=False
+        )

--- a/src/checkers/htmlchecker.py
+++ b/src/checkers/htmlchecker.py
@@ -93,18 +93,25 @@ class HTMLChecker(Checker):
         if not latest_version or not latest_url:
             return
 
+        abs_url = urllib.parse.urljoin(base=url, url=latest_url)
+
+        self._update_version(external_data, latest_version, abs_url)
+
+    def _update_version(
+        self, external_data, latest_version, latest_url, follow_redirects=True
+    ):
         assert latest_version is not None
         assert latest_url is not None
 
-        abs_url = urllib.parse.urljoin(base=url, url=latest_url)
-
         try:
-            new_version, _ = utils.get_extra_data_info_from_url(abs_url)
+            new_version, _ = utils.get_extra_data_info_from_url(
+                latest_url, follow_redirects
+            )
         except urllib.error.HTTPError as e:
-            log.warning("%s returned %s", abs_url, e)
+            log.warning("%s returned %s", latest_url, e)
             external_data.state = ExternalData.State.BROKEN
         except Exception:
-            log.exception("Unexpected exception while checking %s", abs_url)
+            log.exception("Unexpected exception while checking %s", latest_url)
             external_data.state = ExternalData.State.BROKEN
         else:
             external_data.state = ExternalData.State.VALID

--- a/src/lib/utils.py
+++ b/src/lib/utils.py
@@ -115,7 +115,7 @@ def get_extra_data_info_from_head(url):
     wait=wait_fixed(2),
     before_sleep=before_sleep_log(log, logging.DEBUG),
 )
-def get_extra_data_info_from_url(url):
+def get_extra_data_info_from_url(url, follow_redirects=True):
     request = urllib.request.Request(url, headers=HEADERS)
 
     with urllib.request.urlopen(request, timeout=TIMEOUT_SECONDS) as response:
@@ -130,7 +130,11 @@ def get_extra_data_info_from_url(url):
 
     checksum = hashlib.sha256(data).hexdigest()
     external_file = ExternalFile(
-        strip_query(real_url), checksum, size, None, _extract_timestamp(info)
+        strip_query(real_url if follow_redirects else url),
+        checksum,
+        size,
+        None,
+        _extract_timestamp(info),
     )
 
     return external_file, data

--- a/tests/org.flatpak.Flatpak.yml
+++ b/tests/org.flatpak.Flatpak.yml
@@ -1,0 +1,11 @@
+id: org.flatpak.Flatpak
+modules:
+  - name: flatpak
+    sources:
+      - type: archive
+        url: https://github.com/flatpak/flatpak/releases/download/1.8.2/flatpak-1.8.2.tar.xz
+        sha256: 7926625df7c2282a5ee1a8b3c317af53d40a663b1bc6b18a2dc8747e265085b0
+        x-checker-data:
+          type: anitya
+          project-id: 6377
+          url-template: https://github.com/flatpak/flatpak/releases/download/$version/flatpak-$version.tar.xz

--- a/tests/test_anytiachecker.py
+++ b/tests/test_anytiachecker.py
@@ -1,0 +1,36 @@
+import os
+import unittest
+
+from src.checker import ManifestChecker
+from src.lib.utils import init_logging
+
+TEST_MANIFEST = os.path.join(os.path.dirname(__file__), "org.flatpak.Flatpak.yml")
+
+
+class TestAnityaChecker(unittest.TestCase):
+    def setUp(self):
+        init_logging()
+
+    def test_check(self):
+        checker = ManifestChecker(TEST_MANIFEST)
+        ext_data = checker.check()
+
+        self.assertEqual(len(ext_data), 1)
+        data = ext_data[0]
+        self.assertIsNotNone(data.new_version)
+        self.assertRegex(
+            data.new_version.url,
+            r"^https://github.com/flatpak/flatpak/releases/download/[\w\d.]+/flatpak-[\w\d.]+.tar.xz$",
+        )
+        self.assertIsInstance(data.new_version.size, int)
+        self.assertGreater(data.new_version.size, 0)
+        self.assertIsNotNone(data.new_version.checksum)
+        self.assertIsInstance(data.new_version.checksum, str)
+        self.assertNotEqual(
+            data.new_version.checksum,
+            "7926625df7c2282a5ee1a8b3c317af53d40a663b1bc6b18a2dc8747e265085b0",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A dead simple integration with https://release-monitoring.org (or any other hosted Anitya instance).
Given numeric `project-id`, retrieves latest version known to Anitya instance and substitutes it into given `url-template` to get download url.
Also covers "Github checker" use-case, since Anitya has Gihub support.
Closes #16