### PR TITLE
Use unsquashfs to extract appimages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,4 @@
-FROM debian:buster as unappimage
-RUN apt-get update && \
-    env DEBIAN_FRONTEND=noninteractive apt-get install -y make gcc git libelf-dev && \
-    git clone https://github.com/refi64/unappimage && \
-    cd unappimage && make -C squashfs-tools -j$(nproc)
-
 FROM debian:buster
-COPY --from=unappimage /unappimage/squashfs-tools/unappimage /usr/local/bin/
 RUN apt-get update \
   && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
       bubblewrap \
@@ -22,6 +15,8 @@ RUN apt-get update \
       python3-setuptools \
       python3-tenacity \
       python3-toml \
+      python3-pyelftools \
+      squashfs-tools \
   && apt-get clean \
   && rmdir /var/cache/apt/archives/partial
 

--- a/src/lib/utils.py
+++ b/src/lib/utils.py
@@ -30,6 +30,7 @@ import subprocess
 import tempfile
 import urllib.request
 import urllib.parse
+import copy
 
 from collections import OrderedDict
 from ruamel.yaml import YAML
@@ -138,6 +139,15 @@ def get_extra_data_info_from_url(url, follow_redirects=True):
     )
 
     return external_file, data
+
+
+def clear_env(environ):
+    new_env = copy.deepcopy(environ)
+    for varname in new_env.keys():
+        if any(i in varname.lower() for i in ["pass", "token", "secret", "auth"]):
+            log.debug("Removing env %s", varname)
+            new_env.pop(varname)
+    return new_env
 
 
 def run_command(argv, cwd=None, bwrap=True):

--- a/tests/com.unity.UnityHub.yaml
+++ b/tests/com.unity.UnityHub.yaml
@@ -1,0 +1,9 @@
+app-id: com.unity.UnityHub
+modules:
+  - name: unityhub
+    sources:
+      - type: extra-data
+        filename: UnityHubSetup.AppImage
+        url: https://public-cdn.cloud.unity3d.com/hub/prod/UnityHub.AppImage
+        sha256: "0000000000000000000000000000000000000000000000000000000000000000"
+        size: 0

--- a/tests/test_urlchecker.py
+++ b/tests/test_urlchecker.py
@@ -1,0 +1,41 @@
+import unittest
+import os
+
+from src.checker import ManifestChecker
+from src.lib.utils import init_logging
+
+TEST_MANIFEST = os.path.join(os.path.dirname(__file__), "com.unity.UnityHub.yaml")
+
+
+class TestURLChecker(unittest.TestCase):
+    def setUp(self):
+        init_logging()
+
+    def test_check(self):
+        checker = ManifestChecker(TEST_MANIFEST)
+        ext_data = checker.check()
+
+        data = self._find_by_filename(ext_data, "UnityHubSetup.AppImage")
+        self.assertIsNotNone(data)
+        self.assertEqual(data.filename, "UnityHubSetup.AppImage")
+        self.assertIsNotNone(data.new_version)
+        self.assertIsInstance(data.new_version.size, int)
+        self.assertGreater(data.new_version.size, 0)
+        self.assertIsNotNone(data.new_version.checksum)
+        self.assertIsInstance(data.new_version.checksum, str)
+        self.assertNotEqual(
+            data.new_version.checksum,
+            "0000000000000000000000000000000000000000000000000000000000000000",
+        )
+        self.assertIsNotNone(data.new_version.version)
+
+    def _find_by_filename(self, ext_data, filename):
+        for data in ext_data:
+            if data.filename == filename:
+                return data
+        else:
+            return None
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -18,8 +18,10 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 import unittest
+import subprocess
+import os
 
-from src.lib.utils import parse_github_url, strip_query
+from src.lib.utils import parse_github_url, strip_query, clear_env
 
 
 class TestParseGitHubUrl(unittest.TestCase):
@@ -55,6 +57,16 @@ class TestStripQuery(unittest.TestCase):
         url = "https://user:pass@example.com/"
         expected = url
         self.assertEqual(strip_query(url), expected)
+
+
+class TestClearEnv(unittest.TestCase):
+    def test_clear_env(self):
+        os.environ["SOME_TOKEN_HERE"] = "leaked"
+        # pylint: disable=subprocess-run-check
+        proc = subprocess.run(
+            'test -z "$SOME_TOKEN_HERE"', shell=True, env=clear_env(os.environ)
+        )
+        self.assertEqual(proc.returncode, 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
We can use common `unsquashfs` to extract appimages, by calculating file offset ourselves and writing plain squashfs image without ELF portion. Since squashfs-tools package is sufficient and widely available, there is no more need in `unappimage`, and, thus, no reason to fallback to appimage self-extraction when it's not available.

To avoid future merge conflicts, I've included some prior work needed for #90 

This adds dependency on `python3-pyelftools` and `squashfs-tools`.