### PR TITLE
Add property to manually select upstream source

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ For simple checks to see if a URL is broken, no changes are needed.  However,
 you can add additional metadata to the manifest to allow the checker to
 discover new versions.
 
+Some of the following checkers are able to determine upstream version number,
+and automatically add it to releases list in metainfo. To specify which source
+is the app upstream source, set property `is-main-source` to `true` in the
+checker metadata for that source.
+
 ### URL checker
 
 If the upstream vendor has an URL that redirects to the latest version of the

--- a/src/checker.py
+++ b/src/checker.py
@@ -33,6 +33,10 @@ import os
 
 from gi.repository import GLib
 
+
+MAIN_SRC_PROP = "is-main-source"
+
+
 log = logging.getLogger(__name__)
 
 
@@ -255,9 +259,18 @@ class ManifestChecker:
             self._dump_manifest(path)
 
             appdata = find_appdata_file(os.path.splitext(self._manifest)[0])
-            # Guess that the last external source is the one corresponding to the main
-            # application bundle.
-            last_update = datas[-1].new_version
+
+            for data in datas:
+                if data.checker_data.get(MAIN_SRC_PROP):
+                    log.info("Selected upstream source: %s", data.filename)
+                    last_update = data.new_version
+                    break
+            else:
+                # Guess that the last external source is the one corresponding to the main
+                # application bundle.
+                log.warning("Guessed upstream source: %s", data.filename)
+                last_update = datas[-1].new_version
+
             if (
                 appdata is not None
                 and last_update is not None


### PR DESCRIPTION
This adds a new common checker data property for the maintainer to explicity select one of the sources to determine upstream version and, thus, avoid guessing.
Addresses cases like https://github.com/flathub/org.freedesktop.Sdk.Extension.rust-stable/pull/32#pullrequestreview-570074897
