### PR TITLE
Git sources support

### DIFF
--- a/src/checker.py
+++ b/src/checker.py
@@ -27,6 +27,7 @@ from .lib.externaldata import (
     ModuleData,
     ExternalData,
     ExternalDataSource,
+    ExternalGitRepo,
 )
 from .lib.utils import read_manifest, dump_manifest
 
@@ -59,7 +60,7 @@ class ManifestChecker:
         self._manifest = manifest
         self._modules_data: t.Dict[str, ModuleData]
         self._modules_data = {}
-        self._external_data: t.Dict[str, t.List[ExternalData]]
+        self._external_data: t.Dict[str, t.List[t.Union[ExternalData, ExternalGitRepo]]]
         self._external_data = {}
 
         # Initialize checkers

--- a/src/checkers/anityachecker.py
+++ b/src/checkers/anityachecker.py
@@ -10,13 +10,10 @@ log = logging.getLogger(__name__)
 
 
 class AnityaChecker(HTMLChecker):
-    def _should_check(self, external_data):
-        return external_data.checker_data.get("type") == "anitya"
+    CHECKER_DATA_TYPE = "anitya"
 
     def check(self, external_data):
-        if not self._should_check(external_data):
-            log.debug("%s is not a anitya type ext data", external_data.filename)
-            return
+        assert self.should_check(external_data)
 
         instance_url = external_data.checker_data.get(
             "baseurl", "https://release-monitoring.org"

--- a/src/checkers/debianrepochecker.py
+++ b/src/checkers/debianrepochecker.py
@@ -87,17 +87,13 @@ def _get_timestamp_for_candidate(candidate):
 
 
 class DebianRepoChecker(Checker):
+    CHECKER_DATA_TYPE = "debian-repo"
+
     def __init__(self):
         self._pkgs_cache = {}
 
-    def _should_check(self, external_data):
-        return external_data.checker_data.get("type") == "debian-repo"
-
     def check(self, external_data):
-        # Only process external data of the debian-repo
-        if not self._should_check(external_data):
-            LOG.debug("%s is not a debian-repo type ext data", external_data.filename)
-            return
+        assert self.should_check(external_data)
 
         LOG.debug("Checking %s", external_data.filename)
         package_name = external_data.checker_data["package-name"]

--- a/src/checkers/firefoxchecker.py
+++ b/src/checkers/firefoxchecker.py
@@ -39,6 +39,8 @@ log = logging.getLogger(__name__)
 
 
 class FirefoxChecker(Checker):
+    CHECKER_DATA_TYPE = "firefox"
+
     FIREFOX_RELEASE_INFO_URL = (
         "https://product-details.mozilla.org/1.0/firefox_versions.json"
     )
@@ -51,12 +53,8 @@ class FirefoxChecker(Checker):
     CHECKER_BROWSER_DEFAULT_LANGUAGE = "en-US"
     CHECKER_TRANSLATIONS_FILENAME_MATCH = r".+\.xpi$"
 
-    def _should_check(self, module_data):
-        return module_data.checker_data.get("type") == "firefox"
-
-    def check_module(self, module_data, external_data):
-        if not self._should_check(module_data):
-            return
+    def check_module(self, module_data, external_data_list):
+        assert self.should_check_module(module_data, external_data_list)
 
         log.debug("Retrieving latest available firefox version")
         # This should raise an error if either the release info url or
@@ -72,7 +70,7 @@ class FirefoxChecker(Checker):
 
         log.debug("Checking external data")
         browser_data = None
-        for data in external_data:
+        for data in external_data_list:
             if re.match(self.CHECKER_BROWSER_SOURCE_FILENAME, data.filename):
                 browser_data = data
                 break
@@ -86,7 +84,7 @@ class FirefoxChecker(Checker):
 
         added = []
         processed_data = []
-        for data in external_data:
+        for data in external_data_list:
             if data.filename in latest_info:
                 new_version = latest_info[data.filename]
                 data.state = ExternalData.State.VALID

--- a/src/checkers/htmlchecker.py
+++ b/src/checkers/htmlchecker.py
@@ -64,13 +64,10 @@ def get_latest(checker_data, pattern_name, html):
 
 
 class HTMLChecker(Checker):
-    def _should_check(self, external_data):
-        return external_data.checker_data.get("type") == "html"
+    CHECKER_DATA_TYPE = "html"
 
     def check(self, external_data):
-        if not self._should_check(external_data):
-            log.debug("%s is not a html type ext data", external_data.filename)
-            return
+        assert self.should_check(external_data)
 
         url = external_data.checker_data.get("url")
         log.debug("Getting extra data info from %s; may take a while", url)

--- a/src/checkers/jetbrainschecker.py
+++ b/src/checkers/jetbrainschecker.py
@@ -10,15 +10,11 @@ from src.lib.externaldata import ExternalFile, Checker
 log = logging.getLogger(__name__)
 
 
-def _should_check(external_data):
-    return external_data.checker_data.get("type") == "jetbrains"
-
-
 class JetBrainsChecker(Checker):
+    CHECKER_DATA_TYPE = "jetbrains"
+
     def check(self, external_data):
-        if not _should_check(external_data):
-            log.debug("%s is not a jetbrains type ext data", external_data.filename)
-            return
+        assert self.should_check(external_data)
 
         code = external_data.checker_data["code"]
         release_type = external_data.checker_data.get("release-type", "release")

--- a/src/checkers/jsonchecker.py
+++ b/src/checkers/jsonchecker.py
@@ -35,13 +35,10 @@ def query_json(query, data, variables=None):
 
 
 class JSONChecker(HTMLChecker):
-    def _should_check(self, external_data):
-        return external_data.checker_data.get("type") == "json"
+    CHECKER_DATA_TYPE = "json"
 
     def check(self, external_data):
-        if not self._should_check(external_data):
-            log.debug("%s is not a json type ext data", external_data.filename)
-            return
+        assert self.should_check(external_data)
 
         json_url = external_data.checker_data["url"]
         url_query = external_data.checker_data["url-query"]

--- a/src/checkers/rustchecker.py
+++ b/src/checkers/rustchecker.py
@@ -15,14 +15,10 @@ VERSION_RE = re.compile(r"^(\S+)\s+\((\S+)\s+(\S+)\)")
 
 
 class RustChecker(Checker):
-    @staticmethod
-    def _should_check(external_data):
-        return external_data.checker_data.get("type") == "rust"
+    CHECKER_DATA_TYPE = "rust"
 
     def check(self, external_data):
-        if not self._should_check(external_data):
-            log.debug("%s is not a rust type ext data", external_data.filename)
-            return
+        assert self.should_check(external_data)
 
         channel = external_data.checker_data.get("channel", "stable")
         package_name = external_data.checker_data["package"]

--- a/src/checkers/snapcraftchecker.py
+++ b/src/checkers/snapcraftchecker.py
@@ -10,12 +10,10 @@ log = logging.getLogger(__name__)
 
 
 class SnapcraftChecker(Checker):
+    CHECKER_DATA_TYPE = "snapcraft"
+
     _arches = {"x86_64": "amd64", "aarch64": "arm64", "arm": "armhf", "i386": "i386"}
     _BLOCK_SIZE = 65536
-
-    @staticmethod
-    def _should_check(external_data):
-        return external_data.checker_data.get("type") == "snapcraft"
 
     def _get_sha256(self, url: str, sha3_384: str):
         req = urllib.request.Request(url)
@@ -34,9 +32,7 @@ class SnapcraftChecker(Checker):
             return sha2.hexdigest()
 
     def check(self, external_data):
-        if not self._should_check(external_data):
-            log.debug("%s is not a snapcraft type ext data", external_data.filename)
-            return
+        assert self.should_check(external_data)
 
         name = external_data.checker_data["name"]
         channel = external_data.checker_data["channel"]

--- a/src/checkers/urlchecker.py
+++ b/src/checkers/urlchecker.py
@@ -60,8 +60,15 @@ def extract_version(checker_data, url):
 
 
 class URLChecker(Checker):
+    CHECKER_DATA_TYPE = "rotating-url"
+
+    def should_check(self, external_data):
+        return isinstance(external_data, ExternalData)
+
     def check(self, external_data):
-        is_rotating = external_data.checker_data.get("type") == "rotating-url"
+        assert self.should_check(external_data)
+
+        is_rotating = external_data.checker_data.get("type") == self.CHECKER_DATA_TYPE
         if is_rotating:
             url = external_data.checker_data["url"]
         else:

--- a/src/lib/externaldata.py
+++ b/src/lib/externaldata.py
@@ -17,6 +17,8 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+from __future__ import annotations
+
 import abc
 from collections import namedtuple
 from enum import Enum
@@ -24,39 +26,36 @@ import typing as t
 
 import os
 import logging
+import subprocess
+
+from . import utils
 
 
 log = logging.getLogger(__name__)
 
 
 class ModuleData:
-    def __init__(self, name, path, module):
+    def __init__(self, name: str, path: str, module: t.Dict[str, t.Any]):
         self.name = name
         self.path = path
+        self.checker_data: t.Dict[str, t.Any]
         self.checker_data = module.get("x-checker-data", {})
+        self.external_data: t.List[t.Union[ExternalData, ExternalGitRepo]]
         self.external_data = []
 
 
-class ExternalFile(
-    namedtuple("ExternalFile", ("url", "checksum", "size", "version", "timestamp"))
-):
-    __slots__ = ()
+class ExternalBase(abc.ABC):
+    """
+    Abstract base for remote data sources, such as file or VCS repo
+    """
 
-    def matches(self, other):
-        return (
-            self.url == other.url
-            and self.checksum == other.checksum
-            and (self.size is None or other.size is None or self.size == other.size)
-        )
-
-
-class ExternalData(abc.ABC):
-    Type = Enum("Type", "EXTRA_DATA FILE ARCHIVE")
+    Type = Enum("Type", "EXTRA_DATA FILE ARCHIVE GIT")
 
     TYPES = {
         "file": Type.FILE,
         "archive": Type.ARCHIVE,
         "extra-data": Type.EXTRA_DATA,
+        "git": Type.GIT,
     }
 
     class State(Enum):
@@ -66,26 +65,72 @@ class ExternalData(abc.ABC):
         ADDED = 1 << 3  # New source added
         REMOVED = 1 << 4  # Source removed
 
+    current_version: t.Union[ExternalFile, ExternalGitRef]
+    new_version: t.Optional[t.Union[ExternalFile, ExternalGitRef]]
+
+    @classmethod
+    def from_source(cls, source_path, source, sources):
+        url = source.get("url")
+        data_type = cls.TYPES.get(source.get("type"))
+        if url is None or data_type is None:
+            return None
+
+        if data_type == cls.Type.GIT:
+            return ExternalGitRepoSource(source_path, source, sources, url)
+
+        return ExternalDataSource(source_path, source, sources, data_type, url)
+
+    @classmethod
+    def from_sources(cls, source_path, sources):
+        external_data = []
+
+        for source in sources:
+            if isinstance(source, str):
+                continue
+
+            data = cls.from_source(source_path, source, sources)
+            if data:
+                external_data.append(data)
+
+        return external_data
+
+
+class ExternalFile(
+    namedtuple("ExternalFile", ("url", "checksum", "size", "version", "timestamp"))
+):
+    __slots__ = ()
+
+    def matches(self, other: ExternalFile):
+        return (
+            self.url == other.url
+            and self.checksum == other.checksum
+            and (self.size is None or other.size is None or self.size == other.size)
+        )
+
+
+class ExternalData(ExternalBase):
     def __init__(
         self,
-        data_type,
-        source_path,
-        source_parent,
-        filename,
-        url,
-        checksum,
-        size=None,
+        data_type: ExternalBase.Type,
+        source_path: str,
+        source_parent: t.List[dict],
+        filename: str,
+        url: str,
+        checksum: str = None,
+        size: int = None,
         arches=[],
-        checker_data=None,
+        checker_data: dict = None,
     ):
         self.source_path = source_path
         self.source_parent = source_parent
         self.filename = filename
         self.arches = arches
         self.type = data_type
+        assert data_type != self.Type.GIT
         self.checker_data = checker_data or {}
         assert size is None or isinstance(size, int)
         self.current_version = ExternalFile(url, checksum, size, None, None)
+        self.new_version: t.Optional[ExternalFile]
         self.new_version = None
         self.state = ExternalData.State.UNKNOWN
 
@@ -119,7 +164,14 @@ class ExternalData(abc.ABC):
 
 
 class ExternalDataSource(ExternalData):
-    def __init__(self, source_path, source, sources, data_type, url):
+    def __init__(
+        self,
+        source_path: str,
+        source: dict,
+        sources: t.List[dict],
+        data_type: ExternalBase.Type,
+        url: str,
+    ):
         name = (
             source.get("filename")
             or source.get("dest-filename")
@@ -145,29 +197,6 @@ class ExternalDataSource(ExternalData):
 
         self.source = source
 
-    @classmethod
-    def from_source(cls, source_path, source, sources):
-        url = source.get("url")
-        data_type = cls.TYPES.get(source.get("type"))
-        if url is None or data_type is None:
-            return None
-
-        return cls(source_path, source, sources, data_type, url)
-
-    @classmethod
-    def from_sources(cls, source_path, sources):
-        external_data = []
-
-        for source in sources:
-            if isinstance(source, str):
-                continue
-
-            data = cls.from_source(source_path, source, sources)
-            if data:
-                external_data.append(data)
-
-        return external_data
-
     def update(self):
         if self.new_version is not None:
             self.source["url"] = self.new_version.url
@@ -190,6 +219,134 @@ class ExternalDataSource(ExternalData):
             self.source_parent.remove(self.source)
 
 
+class ExternalGitRef(
+    namedtuple(
+        "ExternalGitRef", ("url", "commit", "tag", "branch", "version", "timestamp")
+    )
+):
+    __slots__ = ()
+
+    def get_remote_commit(self):
+        log.debug(
+            "Retrieving commit from %s tag %s branch %s",
+            self.url,
+            self.tag,
+            self.branch,
+        )
+        if self.tag is not None:
+            ref = f"refs/tags/{self.tag}"
+        elif self.branch is not None:
+            ref = f"refs/heads/{self.branch}"
+        else:
+            ref = "HEAD"
+
+        git_cmd = ["git", "ls-remote", self.url, ref]
+        if utils.check_bwrap():
+            git_cmd = utils.wrap_in_bwrap(
+                git_cmd,
+                bwrap_args=[
+                    # fmt: off
+                    "--share-net",
+                    "--dev", "/dev",
+                    "--ro-bind", "/etc/ssl", "/etc/ssl",
+                    "--ro-bind", "/etc/resolv.conf", "/etc/resolv.conf",
+                    # fmt: on
+                ],
+            )
+
+        git_proc = subprocess.run(
+            git_cmd,
+            check=True,
+            stdout=subprocess.PIPE,
+            env=utils.clear_env(os.environ),
+            timeout=5,
+        )
+        got_commit, got_ref = git_proc.stdout.decode().split()
+        assert got_ref == ref
+        return got_commit
+
+    def matches(self, other: ExternalGitRef):
+        return self.url == other.url and (
+            # fmt: off
+            (
+                (self.commit is None and other.commit is None)
+                or self.commit == other.commit
+            )
+            and (
+                (self.tag is None and other.tag is None)
+                or self.tag == other.tag
+            )
+            and (
+                (self.branch is None and other.branch is None)
+                or self.branch == other.branch
+            )
+            # fmt: on
+        )
+
+
+class ExternalGitRepo(ExternalBase):
+    def __init__(
+        self,
+        source_path: str,
+        source_parent: t.List[dict],
+        repo_name: str,
+        url: str,
+        commit: str = None,
+        tag: str = None,
+        branch: str = None,
+        arches=[],
+        checker_data=None,
+    ):
+        self.source_path = source_path
+        self.source_parent = source_parent
+        self.filename = repo_name
+        self.arches = arches
+        self.type = self.TYPES["git"]
+        self.checker_data = checker_data or {}
+        self.current_version = ExternalGitRef(url, commit, tag, branch, None, None)
+        self.new_version: t.Optional[ExternalGitRef]
+        self.new_version = None
+        self.state = ExternalGitRepo.State.UNKNOWN
+
+
+class ExternalGitRepoSource(ExternalGitRepo):
+    def __init__(self, source_path: str, source: dict, sources: t.List[dict], url: str):
+        repo_name = os.path.basename(url)
+        commit = source.get("commit")
+        tag = source.get("tag")
+        branch = source.get("branch")
+        checker_data = source.get("x-checker-data", {})
+        arches = checker_data.get("arches") or source.get("only-arches") or ["x86_64"]
+
+        super().__init__(
+            source_path,
+            sources,
+            repo_name,
+            url,
+            commit,
+            tag,
+            branch,
+            arches,
+            checker_data,
+        )
+
+        self.source = source
+
+    def update(self):
+        if self.new_version is not None:
+            self.source["url"] = self.new_version.url
+            self.source["commit"] = self.new_version.commit
+            if self.new_version.tag is not None:
+                self.source["tag"] = self.new_version.tag
+            if self.new_version.branch is not None:
+                self.source["branch"] = self.new_version.branch
+
+        if self.state == ExternalData.State.ADDED:
+            self.source_parent.append(self.source)
+        elif self.state == ExternalData.State.REMOVED:
+            self.source_parent.remove(self.source)
+
+
 class Checker:
     CHECKER_DATA_TYPE: t.Optional[str] = None
     SUPPORTED_DATA_CLASSES = [ExternalData]
@@ -197,14 +354,16 @@ class Checker:
     def should_check_module(
         self,
         module_data: ModuleData,
-        external_data_list: t.List[ExternalData],
+        external_data_list: t.List[t.Union[ExternalData, ExternalGitRepo]],
     ) -> bool:
         return (
             self.CHECKER_DATA_TYPE is not None
             and module_data.checker_data.get("type") == self.CHECKER_DATA_TYPE
         )
 
-    def should_check(self, external_data: ExternalData) -> bool:
+    def should_check(
+        self, external_data: t.Union[ExternalData, ExternalGitRepo]
+    ) -> bool:
         supported = any(
             isinstance(external_data, c) for c in self.SUPPORTED_DATA_CLASSES
         )
@@ -217,9 +376,9 @@ class Checker:
     def check_module(
         self,
         module_data: ModuleData,
-        external_data_list: t.List[ExternalData],
+        external_data_list: t.List[t.Union[ExternalData, ExternalGitRepo]],
     ):
         pass
 
-    def check(self, external_data: ExternalData):
+    def check(self, external_data: t.Union[ExternalData, ExternalGitRepo]):
         pass

--- a/src/lib/externaldata.py
+++ b/src/lib/externaldata.py
@@ -20,6 +20,7 @@
 import abc
 from collections import namedtuple
 from enum import Enum
+import typing as t
 
 import os
 import logging
@@ -190,8 +191,35 @@ class ExternalDataSource(ExternalData):
 
 
 class Checker:
-    def check_module(self, module_data, external_data_list):
+    CHECKER_DATA_TYPE: t.Optional[str] = None
+    SUPPORTED_DATA_CLASSES = [ExternalData]
+
+    def should_check_module(
+        self,
+        module_data: ModuleData,
+        external_data_list: t.List[ExternalData],
+    ) -> bool:
+        return (
+            self.CHECKER_DATA_TYPE is not None
+            and module_data.checker_data.get("type") == self.CHECKER_DATA_TYPE
+        )
+
+    def should_check(self, external_data: ExternalData) -> bool:
+        supported = any(
+            isinstance(external_data, c) for c in self.SUPPORTED_DATA_CLASSES
+        )
+        applicable = (
+            self.CHECKER_DATA_TYPE is not None
+            and external_data.checker_data.get("type") == self.CHECKER_DATA_TYPE
+        )
+        return applicable and supported
+
+    def check_module(
+        self,
+        module_data: ModuleData,
+        external_data_list: t.List[ExternalData],
+    ):
         pass
 
-    def check(self, external_data):
+    def check(self, external_data: ExternalData):
         pass

--- a/src/lib/utils.py
+++ b/src/lib/utils.py
@@ -44,7 +44,7 @@ from tenacity import (
 )
 from elftools.elf.elffile import ELFFile
 
-from .externaldata import ExternalFile
+from . import externaldata
 
 import gi
 
@@ -108,7 +108,7 @@ def get_extra_data_info_from_head(url):
         info = response.info()
         size = int(info["Content-Length"])
 
-    return ExternalFile(
+    return externaldata.ExternalFile(
         strip_query(real_url), None, size, None, _extract_timestamp(info)
     )
 
@@ -133,7 +133,7 @@ def get_extra_data_info_from_url(url, follow_redirects=True):
         size = len(data)
 
     checksum = hashlib.sha256(data).hexdigest()
-    external_file = ExternalFile(
+    external_file = externaldata.ExternalFile(
         strip_query(real_url if follow_redirects else url),
         checksum,
         size,

--- a/src/main.py
+++ b/src/main.py
@@ -249,6 +249,11 @@ def main():
         action="store_true",
     )
     parser.add_argument(
+        "--edit-only",
+        help="Do not commit changes, only update files (implies --update)",
+        action="store_true",
+    )
+    parser.add_argument(
         "--filter-type",
         help="Only check external data of the given type",
         choices=types,
@@ -264,8 +269,10 @@ def main():
     manifest_checker.check(filter_type)
 
     if print_outdated_external_data(manifest_checker):
-        if args.update or args.commit_only:
+        if args.update or args.commit_only or args.edit_only:
             changes = manifest_checker.update_manifests()
+            if args.edit_only:
+                return
             if changes:
                 with indir(os.path.dirname(args.manifest)):
                     subject, body, branch = commit_changes(changes)

--- a/src/main.py
+++ b/src/main.py
@@ -71,12 +71,21 @@ def print_outdated_external_data(manifest_checker):
             else:
                 print(" A new version is available:")
 
-            print(
-                "  URL:     {url}\n"
-                "  SHA256:  {checksum}\n"
-                "  Size:    {size}\n"
-                "  Version: {version}\n".format(**data.new_version._asdict())
-            )
+            if data.type == ExternalData.Type.GIT:
+                print(
+                    "  URL:     {url}\n"
+                    "  Commit:  {commit}\n"
+                    "  Tag:     {tag}\n"
+                    "  Branch:  {branch}\n"
+                    "  Version: {version}\n".format(**data.new_version._asdict())
+                )
+            else:
+                print(
+                    "  URL:     {url}\n"
+                    "  SHA256:  {checksum}\n"
+                    "  Size:    {size}\n"
+                    "  Version: {version}\n".format(**data.new_version._asdict())
+                )
         elif data.state == ExternalData.State.BROKEN:
             print(
                 "BROKEN: {}\n"

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -43,6 +43,9 @@ NUM_ALL_EXT_DATA = (
 
 
 class DummyChecker(Checker):
+    def should_check(self, external_data):
+        return True
+
     def check(self, external_data):
         logging.debug(
             "Phony checker checking external data %s and all is always good",
@@ -50,7 +53,7 @@ class DummyChecker(Checker):
         )
 
 
-class UpdateEverythingChecker(Checker):
+class UpdateEverythingChecker(DummyChecker):
     SIZE = 0
     # echo -n | sha256sum
     CHECKSUM = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
@@ -67,7 +70,7 @@ class UpdateEverythingChecker(Checker):
         )
 
 
-class RemoveEverythingChecker(Checker):
+class RemoveEverythingChecker(DummyChecker):
     def check(self, external_data):
         external_data.state = ExternalData.State.REMOVED
 


### PR DESCRIPTION
This requires some core rewrite, because initially f-e-d-c was intended for extra-data checking only, and was dsigned with assumption that the upstream source is always a file.

General approach here is to abstract some `ExternalData` class methods, add a sibling class `ExternalGitRepo`, and pass to each checker `external_data` of either type (`ExternalData` or `ExternalGitRepo`). Then each checker decides on its own what to do with given `external_data` (e.g. skip it if it's not supported).

Some of the current checkers can potentially support git (e.g. `json` and `anytia`), others can't (e.g. `rotating-url` and `snapcraft`), and we can add a checher that only supports git (some `GitChecker`).
Future work includes adding git support to individual checkers, where applicable.

See also #33