### PR TITLE
Fix jenkins integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,14 @@ RUN apt-get update && \
   && apt-get clean \
   && rmdir /var/cache/apt/archives/partial
 
+# Creating the user is required because jenkins runs he container
+# with the same user as the host (with '-u <uid>:<gid>')
+# but without the user existing 'git' fails with 'No user exists for uid ...'.
+ARG USER_ID=1000
+ARG GROUP_ID=1000
+RUN groupadd -g $GROUP_ID user && \
+    useradd -u $USER_ID -s /bin/sh -m -g user user
+
 COPY src /app/src
 COPY flatpak-external-data-checker /app/
 COPY canonicalize-manifest /app/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,7 @@ node('flatpak-builder') {
              * a workaround to make sure the user running the container exists
              * inside of it (see Dockerfile). This is needed because jenkins runs
              * the container with the same user as the host (with '-u <uid>:<gid>')
-             * but 'git push' fails with 'No user exists for uid ...' if the user
+             * but 'git' fails with 'No user exists for uid ...' if the user
              * doesn't exist inside the container (other option is to mount
              * '/etc/passwd' as a volume and export HOME/USER envs accordingly
              * when running the container ('image.inside' below)).

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ node('flatpak-builder') {
             try {
                 /* The '--privileged' param is required to run 'bwrap' which is used
                  * by the flatpak external data checker */
-                image.inside('--privileged') {
+                image.inside('--privileged --entrypoint=""') {
                     sshagent(credentials: [ 'fe45ca53-7c92-47db-b3b1-b8d0cc8507ed' ]) {
                         withCredentials([string(credentialsId: 'github-api-token-rw-jobs', variable: 'GITHUB_TOKEN')]) {
                             timeout(time: 20, unit: 'MINUTES') {


### PR DESCRIPTION
This fixes Endless Jenkins integration that got broken after 064fdeaa85e00bf72832d1991a571b4e009137ae.

~~It should still allow running the container as it is now but with some small caveats (e.g. if passing only a manifest as param to "docker run" it has to end with ".json", ".yml" or ".yaml").~~