### PR TITLE
Don't add new commit property to git sources

### DIFF
--- a/src/checkers/gitchecker.py
+++ b/src/checkers/gitchecker.py
@@ -102,12 +102,9 @@ class GitChecker(Checker):
             )
             return
 
-        if (
-            external_data.current_version.commit is None
-            and external_data.current_version.tag is None
-        ):
+        if external_data.current_version.commit is None:
             log.info(
-                "Skipping source %s, not pinned to tag or commit",
+                "Skipping source %s, not pinned to commit",
                 external_data.filename,
             )
             return

--- a/tests/com.virustotal.Uploader.yml
+++ b/tests/com.virustotal.Uploader.yml
@@ -16,6 +16,7 @@ modules:
       - type: git
         url: https://github.com/VirusTotal/yara.git
         tag: "4.0.4"
+        commit: 814b6296f4ce389c8c16b5508b56f1f3d9af554d
 
   - name: yara-python
     sources:
@@ -38,7 +39,7 @@ modules:
 
   - name: jansson
     sources:
-      # No commit specified
+      # No commit specified, should be skipped
       - type: git
         url: "https://github.com/akheron/jansson.git"
         tag: v2.13.1

--- a/tests/test_gitchecker.py
+++ b/tests/test_gitchecker.py
@@ -22,19 +22,8 @@ class TestGitChecker(unittest.TestCase):
             self.assertIsInstance(data, ExternalGitRepo)
             self.assertIsInstance(data.current_version, ExternalGitRef)
             if data.filename == "jansson.git":
-                self.assertEqual(data.state, data.State.BROKEN)
-                self.assertIsNotNone(data.new_version)
-                self.assertEqual(data.current_version.url, data.new_version.url)
-                self.assertIsNotNone(data.new_version.tag)
-                self.assertEqual(data.current_version.tag, data.new_version.tag)
-                self.assertIsNotNone(data.new_version.commit)
-                self.assertEqual(
-                    data.new_version.commit, "e9ebfa7e77a6bee77df44e096b100e7131044059"
-                )
-                self.assertNotEqual(
-                    data.current_version.commit, data.new_version.commit
-                )
-                self.assertFalse(data.current_version.matches(data.new_version))
+                self.assertEqual(data.state, data.State.UNKNOWN)
+                self.assertIsNone(data.new_version)
             elif data.filename == "c-vtapi.git":
                 self.assertEqual(data.state, data.State.BROKEN)
                 self.assertIsNotNone(data.new_version)
@@ -82,15 +71,7 @@ class TestGitChecker(unittest.TestCase):
         elif data.filename == "yara-python.git":
             self.assertEqual(data.source, orig_source)
         elif data.filename == "jansson.git":
-            self.assertNotEqual(data.source, orig_source)
-            self.assertEqual(
-                list(data.source.keys()), list(orig_source.keys()) + ["commit"]
-            )
-            self.assertNotIn("commit", orig_source)
-            self.assertIn("commit", data.source)
-            self.assertIn("tag", data.source)
-            self.assertEqual(data.source["tag"], data.new_version.tag)
-            self.assertEqual(data.source["commit"], data.new_version.commit)
+            self.assertEqual(data.source, orig_source)
         elif data.filename == "c-vtapi.git":
             self.assertNotEqual(data.source, orig_source)
             self.assertEqual(data.source.keys(), orig_source.keys())


### PR DESCRIPTION
When checking if git source is still valid, only check if the tag/branch tip still points to specified commit. If no commit was specified, don't add it.

I'm not entirely sure if we should add commit or not. Specifying commit is good for reproducibility, but the maintainer may not want it (e.g. if the tag is intentionally being re-tagged periodically).