### PR TITLE
Make state changes consistent among checker

### DIFF
--- a/src/checker.py
+++ b/src/checker.py
@@ -189,6 +189,13 @@ class ManifestChecker:
                             type(checker).__name__,
                         )
                         break
+                    if data.new_version is not None:
+                        log.debug(
+                            "Source %s: got new version from %s, skipping remaining checkers",
+                            data.filename,
+                            type(checker).__name__,
+                        )
+                        break
                 ext_data_checked.append(data)
 
         return list(set(ext_data_checked))

--- a/src/checkers/anityachecker.py
+++ b/src/checkers/anityachecker.py
@@ -71,4 +71,5 @@ class AnityaChecker(HTMLChecker):
 
         if not external_data.current_version.matches(new_version):
             external_data.new_version = new_version
+        else:
             external_data.state = external_data.State.VALID

--- a/src/checkers/debianrepochecker.py
+++ b/src/checkers/debianrepochecker.py
@@ -123,6 +123,8 @@ class DebianRepoChecker(Checker):
 
             if not external_data.current_version.matches(new_version):
                 external_data.new_version = new_version
+            else:
+                external_data.state = external_data.State.VALID
 
     def _translate_arch(self, arch):
         # Because architecture names in Debian differ from Flatpak's

--- a/src/checkers/gitchecker.py
+++ b/src/checkers/gitchecker.py
@@ -82,12 +82,10 @@ class GitChecker(Checker):
             version=latest_tag.version,
             timestamp=None,
         )
-        if external_data.current_version.matches(new_version):
-            log.debug("No update for git repo %s", external_data.current_version.url)
-            external_data.state = ExternalGitRepo.State.VALID
+        if not external_data.current_version.matches(new_version):
+            external_data.new_version = new_version
         else:
             external_data.state = ExternalGitRepo.State.VALID
-            external_data.new_version = new_version
 
     @staticmethod
     def _check_still_valid(external_data):

--- a/src/checkers/htmlchecker.py
+++ b/src/checkers/htmlchecker.py
@@ -108,7 +108,8 @@ class HTMLChecker(Checker):
             log.exception("Unexpected exception while checking %s", latest_url)
             external_data.state = ExternalData.State.BROKEN
         else:
-            external_data.state = ExternalData.State.VALID
             new_version = new_version._replace(version=latest_version)
             if not external_data.current_version.matches(new_version):
                 external_data.new_version = new_version
+            else:
+                external_data.state = ExternalData.State.VALID

--- a/src/checkers/jetbrainschecker.py
+++ b/src/checkers/jetbrainschecker.py
@@ -43,3 +43,5 @@ class JetBrainsChecker(Checker):
 
         if not external_data.current_version.matches(new_version):
             external_data.new_version = new_version
+        else:
+            external_data.state = external_data.State.VALID

--- a/src/checkers/jsonchecker.py
+++ b/src/checkers/jsonchecker.py
@@ -99,5 +99,6 @@ class JSONChecker(HTMLChecker):
             new_version = new_version.fetch_remote()
 
         if not external_data.current_version.matches(new_version):
-            external_data.state = ExternalData.State.VALID
             external_data.new_version = new_version
+        else:
+            external_data.state = ExternalData.State.VALID

--- a/src/checkers/rustchecker.py
+++ b/src/checkers/rustchecker.py
@@ -50,3 +50,5 @@ class RustChecker(Checker):
             )
             if not external_data.current_version.matches(new_version):
                 external_data.new_version = new_version
+            else:
+                external_data.state = external_data.State.VALID

--- a/src/checkers/snapcraftchecker.py
+++ b/src/checkers/snapcraftchecker.py
@@ -73,3 +73,5 @@ class SnapcraftChecker(Checker):
 
                 if not external_data.current_version.matches(new_version):
                     external_data.new_version = new_version
+                else:
+                    external_data.state = external_data.State.VALID

--- a/src/main.py
+++ b/src/main.py
@@ -59,14 +59,14 @@ def indir(path):
 def print_outdated_external_data(manifest_checker):
     ext_data = manifest_checker.get_outdated_external_data()
     for data in ext_data:
+        state_txt = (
+            data.state.name
+            if data.state == ExternalData.State.BROKEN
+            else "CHANGE SOON"
+        )
+        print("{}: {}".format(state_txt, data.filename))
         if data.new_version:
-            if data.state == ExternalData.State.VALID:
-                print("CHANGE SOON: {}\n" " Has a new version:".format(data.filename))
-            elif data.state == ExternalData.State.BROKEN:
-                print("BROKEN: {}\n" " Has a new version:".format(data.filename))
-            else:
-                print(" A new version is available:")
-
+            print(" Has a new version:")
             if data.type == ExternalData.Type.GIT:
                 print(
                     "  URL:     {url}\n"
@@ -83,10 +83,7 @@ def print_outdated_external_data(manifest_checker):
                     "  Version: {version}\n".format(**data.new_version._asdict())
                 )
         elif data.state == ExternalData.State.BROKEN:
-            print(
-                "BROKEN: {}\n"
-                " Unreachable URL: {}".format(data.filename, data.current_version.url)
-            )
+            print(" Couldn't get new version for {}".format(data.current_version.url))
         print("")
 
     return len(ext_data)

--- a/tests/test_anytiachecker.py
+++ b/tests/test_anytiachecker.py
@@ -36,9 +36,13 @@ class TestAnityaChecker(unittest.TestCase):
             elif data.filename == "ostree.git":
                 self.assertIsNotNone(data.new_version)
                 self.assertIsInstance(data.new_version, ExternalGitRef)
-                self.assertIsNotNone(data.new_version.version)
+                self.assertIsNotNone(data.new_version.commit)
                 self.assertIsNotNone(data.new_version.tag)
+                self.assertNotEqual(
+                    data.new_version.commit, data.current_version.commit
+                )
                 self.assertNotEqual(data.new_version.tag, data.current_version.tag)
+                self.assertIsNotNone(data.new_version.version)
                 self.assertNotEqual(
                     data.new_version.commit, data.current_version.commit
                 )

--- a/tests/test_gitchecker.py
+++ b/tests/test_gitchecker.py
@@ -59,12 +59,15 @@ class TestGitChecker(unittest.TestCase):
                 self.assertEqual(data.state, data.State.VALID)
                 self.assertIsNone(data.new_version)
             elif data.filename == "extra-cmake-modules.git":
-                self.assertEqual(data.state, data.State.VALID)
                 self.assertIsNotNone(data.new_version)
                 self.assertIsNone(data.new_version.branch)
                 self.assertIsNotNone(data.new_version.commit)
                 self.assertIsNotNone(data.new_version.tag)
                 self.assertIsNotNone(data.new_version.version)
+                self.assertNotEqual(data.new_version.tag, data.current_version.tag)
+                self.assertNotEqual(
+                    data.new_version.commit, data.current_version.commit
+                )
                 self.assertRegex(data.new_version.tag, r"^[vV][\d.]+$")
                 self.assertRegex(data.new_version.version, r"^[\d.]+$")
             else:

--- a/tests/test_htmlchecker.py
+++ b/tests/test_htmlchecker.py
@@ -49,6 +49,7 @@ class TestHTMLChecker(unittest.TestCase):
             data.new_version.url,
             r"^https?://www.x.org/releases/individual/app/xeyes-[\d\.-]+.tar.bz2",  # noqa: E501
         )
+        self.assertNotEqual(data.new_version.url, data.current_version.url)
         self.assertIsNotNone(data.new_version.version)
         self.assertIsInstance(data.new_version.size, int)
         self.assertGreater(data.new_version.size, 0)

--- a/tests/test_jsonchecker.py
+++ b/tests/test_jsonchecker.py
@@ -40,6 +40,10 @@ class TestJSONChecker(unittest.TestCase):
                 self.assertEqual(data.current_version.url, data.new_version.url)
                 self.assertIsNotNone(data.new_version.tag)
                 self.assertIsNotNone(data.new_version.commit)
+                self.assertNotEqual(data.new_version.tag, data.current_version.tag)
+                self.assertNotEqual(
+                    data.new_version.commit, data.current_version.commit
+                )
                 self.assertNotEqual(
                     data.new_version.commit, "e03900b038a274ee2f1341039e9003875c11e47d"
                 )


### PR DESCRIPTION
Checkers that check for upstream updates should all treat external data state the same way:

- If new version matches current, set state to VALID
- If new version is different, add it and don't change state

This will make checking faster in some cases by avoiding applying validity checker after update checker (e.g. URLChecker after AnityaChecker).