### PR TITLE
Use requests module to download files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ RUN apt-get update && \
       python3-pip \
       python3-ruamel.yaml \
       python3-setuptools \
-      python3-tenacity \
       python3-toml \
       python3-pyelftools \
       squashfs-tools \

--- a/src/checkers/htmlchecker.py
+++ b/src/checkers/htmlchecker.py
@@ -104,9 +104,6 @@ class HTMLChecker(Checker):
         except urllib.error.HTTPError as e:
             log.warning("%s returned %s", latest_url, e)
             external_data.state = ExternalData.State.BROKEN
-        except Exception:
-            log.exception("Unexpected exception while checking %s", latest_url)
-            external_data.state = ExternalData.State.BROKEN
         else:
             new_version = new_version._replace(version=latest_version)
             external_data.set_new_version(new_version)

--- a/src/checkers/htmlchecker.py
+++ b/src/checkers/htmlchecker.py
@@ -20,11 +20,11 @@
 
 import logging
 import re
-import urllib.error
 import urllib.parse
-import urllib.request
 from string import Template
 from distutils.version import LooseVersion
+
+import requests
 
 from src.lib import utils
 from src.lib.externaldata import ExternalData, Checker
@@ -69,10 +69,10 @@ class HTMLChecker(Checker):
     def check(self, external_data):
         assert self.should_check(external_data)
 
-        url = external_data.checker_data.get("url")
-        log.debug("Getting extra data info from %s; may take a while", url)
-        resp = urllib.request.urlopen(url)
-        html = resp.read().decode()
+        url = external_data.checker_data["url"]
+        with requests.get(url) as response:
+            response.raise_for_status()
+            html = response.text
 
         latest_version = get_latest(external_data.checker_data, "version-pattern", html)
         latest_url = get_latest(external_data.checker_data, "url-pattern", html)
@@ -101,7 +101,10 @@ class HTMLChecker(Checker):
             new_version, _ = utils.get_extra_data_info_from_url(
                 latest_url, follow_redirects
             )
-        except urllib.error.HTTPError as e:
+        except (
+            requests.exceptions.HTTPError,
+            requests.exceptions.ConnectionError,
+        ) as e:
             log.warning("%s returned %s", latest_url, e)
             external_data.state = ExternalData.State.BROKEN
         else:

--- a/src/checkers/urlchecker.py
+++ b/src/checkers/urlchecker.py
@@ -85,9 +85,6 @@ class URLChecker(Checker):
         except (urllib.error.HTTPError, urllib.error.URLError) as e:
             log.warning("%s returned %s", url, e)
             external_data.state = ExternalData.State.BROKEN
-        except Exception:
-            log.exception("Unexpected exception while checking %s", url)
-            external_data.state = ExternalData.State.BROKEN
         else:
             if url.endswith(".AppImage"):
                 version_string = utils.extract_appimage_version(

--- a/src/checkers/urlchecker.py
+++ b/src/checkers/urlchecker.py
@@ -33,8 +33,9 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 import logging
-import urllib.error
 import re
+
+import requests
 
 from src.lib.externaldata import ExternalData, Checker
 from src.lib import utils
@@ -82,7 +83,10 @@ class URLChecker(Checker):
 
         try:
             new_version, data = utils.get_extra_data_info_from_url(url)
-        except (urllib.error.HTTPError, urllib.error.URLError) as e:
+        except (
+            requests.exceptions.HTTPError,
+            requests.exceptions.ConnectionError,
+        ) as e:
             log.warning("%s returned %s", url, e)
             external_data.state = ExternalData.State.BROKEN
         else:


### PR DESCRIPTION
requests module is easier to use, has builtin debug logging and it provides a builtin mechanism for retries, so we can get rid of `tenacity` dependency (we already depend on `requests` through `PyGithub`).

This PR shouldn't change behavior (except for default User-Agent change), just some internal work. But since it's more of a personal preference, asking for @wjt and @andrunko consent.