### PR TITLE
Support source packages in debian repo

### DIFF
--- a/tests/org.debian.tracker.pkg.apt.yml
+++ b/tests/org.debian.tracker.pkg.apt.yml
@@ -1,0 +1,27 @@
+id: org.debian.tracker.pkg.apt
+modules:
+      - name: python-apt
+        sources:
+          - type: archive
+            url: "http://deb.debian.org/debian/python-apt-source.tar.xz"
+            sha256: "0000000000000000000000000000000000000000000000000000000000000000"
+            x-checker-data:
+              type: debian-repo
+              root: http://deb.debian.org/debian
+              dist: buster
+              component: main
+              package-name: python-apt
+        modules:
+
+          - name: apt
+            sources:
+              - type: file
+                only-arches: [ "aarch64" ]
+                url: "http://deb.debian.org/debian/apt-aarch64.deb"
+                sha256: "0000000000000000000000000000000000000000000000000000000000000000"
+                x-checker-data:
+                  type: debian-repo
+                  root: http://deb.debian.org/debian
+                  dist: buster
+                  component: main
+                  package-name: apt

--- a/tests/org.debian.tracker.pkg.apt.yml
+++ b/tests/org.debian.tracker.pkg.apt.yml
@@ -7,10 +7,11 @@ modules:
             sha256: "0000000000000000000000000000000000000000000000000000000000000000"
             x-checker-data:
               type: debian-repo
-              root: http://deb.debian.org/debian
+              root: http://deb.debian.org/debian/
               dist: buster
               component: main
               package-name: python-apt
+              source: true
         modules:
 
           - name: apt

--- a/tests/org.externaldatachecker.Manifest.json
+++ b/tests/org.externaldatachecker.Manifest.json
@@ -23,50 +23,6 @@
                 },
                 {
                     "type": "extra-data",
-                    "filename": "flatpak",
-                    "url": "http://ftp.de.debian.org/some-broken-debian-pkg.deb",
-                    "sha256": "000000000000000000000000000000000000000000000000000000000000000000",
-                    "size": 1234567,
-                    "x-checker-data": {
-                        "type": "debian-repo",
-                        "package-name": "flatpak",
-                        "root": "https://deb.debian.org/debian/",
-                        "dist": "stable",
-                        "component": "main",
-                        "arches": ["i386"]
-                    }
-                },
-                {
-                    "type": "extra-data",
-                    "filename": "flatpak",
-                    "only-arches": ["arm"],
-                    "url": "http://ftp.de.debian.org/some-broken-debian-pkg.deb",
-                    "sha256": "000000000000000000000000000000000000000000000000000000000000000000",
-                    "size": 1234567,
-                    "x-checker-data": {
-                        "type": "debian-repo",
-                        "package-name": "flatpak",
-                        "root": "https://deb.debian.org/debian/",
-                        "dist": "stable",
-                        "component": "main"
-                    }
-                },
-		{
-                    "type": "extra-data",
-                    "filename": "flatpak",
-                    "url": "http://debian.org",
-                    "sha256": "just-a-valid-url-0000000000000000000000000000000000000000000000000",
-                    "size": 1234567,
-                    "x-checker-data": {
-                        "type": "debian-repo",
-                        "package-name": "flatpak",
-                        "root": "https://deb.debian.org/debian/",
-                        "dist": "stable",
-                        "component": "main"
-                    }
-                },
-                {
-                    "type": "extra-data",
                     "filename": "dropbox.tgz",
                     "only-arches": ["x86_64"],
                     "url": "https://clientupdates.dropboxstatic.com/BROKEN_LINK",

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -36,7 +36,7 @@ TEST_MANIFEST = os.path.join(
 )
 NUM_ARCHIVE_IN_MANIFEST = 1
 NUM_FILE_IN_MANIFEST = 1
-NUM_EXTRA_DATA_IN_MANIFEST = 6
+NUM_EXTRA_DATA_IN_MANIFEST = 3
 NUM_ALL_EXT_DATA = (
     NUM_ARCHIVE_IN_MANIFEST + NUM_FILE_IN_MANIFEST + NUM_EXTRA_DATA_IN_MANIFEST
 )
@@ -238,7 +238,7 @@ modules:
             if data.new_version:
                 ext_data_with_new_version += 1
 
-        self.assertEqual(ext_data_with_new_version, 4)
+        self.assertEqual(ext_data_with_new_version, 1)
 
         file_ext_data = checker.get_external_data(ExternalData.Type.FILE)
         self.assertEqual(len(file_ext_data), NUM_FILE_IN_MANIFEST)

--- a/tests/test_debianrepochecker.py
+++ b/tests/test_debianrepochecker.py
@@ -29,3 +29,15 @@ class TestDebianRepoChecker(unittest.TestCase):
             self.assertRegex(
                 data.new_version.url, r"http://deb.debian.org/debian/pool/main/.+"
             )
+            if data.filename == "python-apt-source.tar.xz":
+                self.assertRegex(
+                    data.new_version.url,
+                    r"http://deb.debian.org/debian/pool/main/p/python-apt/python-apt_(\d[\d\.-]+\d).tar.xz",
+                )
+            elif data.filename == "apt-aarch64.deb":
+                self.assertRegex(
+                    data.new_version.url,
+                    r"http://deb.debian.org/debian/pool/main/a/apt/apt_(\d[\d\.-]+\d)_arm64.deb",
+                )
+            else:
+                self.fail(f"Unknown data {data.filename}")

--- a/tests/test_debianrepochecker.py
+++ b/tests/test_debianrepochecker.py
@@ -1,0 +1,31 @@
+import unittest
+import os
+
+from src.checker import ManifestChecker
+from src.lib.utils import init_logging
+
+TEST_MANIFEST = os.path.join(
+    os.path.dirname(__file__), "org.debian.tracker.pkg.apt.yml"
+)
+
+
+class TestDebianRepoChecker(unittest.TestCase):
+    def setUp(self):
+        init_logging()
+
+    def test_check(self):
+        checker = ManifestChecker(TEST_MANIFEST)
+        ext_data = checker.check()
+        for data in ext_data:
+            self.assertIsNotNone(data)
+            self.assertIsNotNone(data.new_version)
+            self.assertIsNotNone(data.new_version.url)
+            self.assertIsNotNone(data.new_version.checksum)
+            self.assertIsNotNone(data.new_version.version)
+            self.assertNotEqual(data.new_version.url, data.current_version.url)
+            self.assertNotEqual(
+                data.new_version.checksum, data.current_version.checksum
+            )
+            self.assertRegex(
+                data.new_version.url, r"http://deb.debian.org/debian/pool/main/.+"
+            )


### PR DESCRIPTION
Can be useful for building sources that are normally hosted in a deb repo, e.g. ubuntu's `properties-cpp`, or `dpkg` and `apt`.