### PR TITLE
Collect and report problems during update

### DIFF
--- a/tests/net.invisible_island.xterm.appdata.xml
+++ b/tests/net.invisible_island.xterm.appdata.xml
@@ -1,3 +1,4 @@
+<!-- this comment breaks XML parsing -->
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
   <id>net.invisible_island.xterm</id>

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -35,9 +35,13 @@ class TestEntrypoint(unittest.TestCase):
         self.test_dir.cleanup()
 
     def _run_cmd(self, cmd):
-        return subprocess.run(cmd, cwd=self.test_dir.name, check=True)
+        return subprocess.run(
+            cmd, cwd=self.test_dir.name, stdout=subprocess.PIPE, text=True, check=True
+        )
 
     def test_full_run(self):
         args = main.parse_cli_args(["--update", "--commit-only", self.manifest_path])
         self.assertEqual(main.run_with_args(args), 2)
         self.assertEqual(main.run_with_args(args), 0)
+        commit_msg = self._run_cmd(["git", "log", "-1", "--pretty=%B"]).stdout
+        self.assertIn("Failed to update appdata", commit_msg)


### PR DESCRIPTION
As originally suggested in https://github.com/flathub/flatpak-external-data-checker/issues/128#issuecomment-780864107, if we got some non-fatal error during run, we should collect them and report to the maintainer.

I'm not sure if we should include errors in commit messages. It doesn't feel like the right place for error logs.