### PR TITLE
htmlchecker: Support combined url/version pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,8 @@ HTML page which contains this information:
 "x-checker-data": {
     "type": "html",
     "url": "https://www.example.com/download.html",
-    "version-pattern": "The latest version is ([\d\.-]*)",
-    "url-pattern": "https://www.example.com/pub/foo/v(\d+)/foo.tar.gz"
+    "version-pattern": "The latest version is ([\\d\\.-]+)",
+    "url-pattern": "(https://www.example.com/pub/foo/v([\\d\\.-]+)/foo.tar.gz)"
 }
 ```
 
@@ -148,7 +148,7 @@ the retrieved version:
 "x-checker-data": {
     "type": "html",
     "url": "https://www.example.com/download.html",
-    "version-pattern": "The latest version is ([\d\.-]*)",
+    "version-pattern": "The latest version is ([\\d\\.-]*)",
     "url-template": "https://www.example.com/$version/v$version.tar.gz"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -153,6 +153,19 @@ the retrieved version:
 }
 ```
 
+If the HTML page contains multiple versions with download links,
+set single pattern containing two nested match groups for both url and version:
+
+```json
+"x-checker-data": {
+    "type": "html",
+    "url": "https://sourceforge.net/projects/qrupdate/rss",
+    "pattern": "<link>(https://sourceforge.net/.+/qrupdate-([\\d\\.]+\\d).tar.gz)/download</link>"
+}
+```
+
+To disable sorting and get first matched version/url, set `sort-matches` to `false`.
+
 ### Git checker
 
 To check for latest git tag in corresponding git source repo, add checker

--- a/tests/org.x.xeyes.yml
+++ b/tests/org.x.xeyes.yml
@@ -21,3 +21,35 @@ modules:
           url: https://www.x.org/releases/individual/app/
           version-pattern: ico-(1\.0\.5)\.tar\.bz2
           url-template: https://www.x.org/releases/individual/app/ico-$version.tar.bz2
+
+  - name: libXScrnSaver
+    sources:
+      - type: archive
+        url: https://www.x.org/releases/individual/lib/libXScrnSaver-1.2.2.tar.bz2
+        sha256: "0000000000000000000000000000000000000000000000000000000000000000"
+        x-checker-data:
+          type: html
+          url: https://www.x.org/releases/individual/lib/
+          pattern: (libXScrnSaver-([\d\.]+\d).tar.bz2)
+
+  - name: qrupdate
+    sources:
+      - type: archive
+        url: https://sourceforge.net/projects/qrupdate/files/qrupdate/1.1/qrupdate-1.1.0.tar.gz
+        sha256: "0000000000000000000000000000000000000000000000000000000000000000"
+        x-checker-data:
+          type: html
+          url: https://sourceforge.net/projects/qrupdate/rss
+          pattern: <link>(https://sourceforge.net/.+/qrupdate-([\d\.]+\d)\.tar\.gz)/download</link>
+          sort-matches: false
+
+  - name: libFS
+    sources:
+      - type: archive
+        url: http://some-incorrect.url/libFS-1.0.7.tar.bz2
+        sha256: "0000000000000000000000000000000000000000000000000000000000000000"
+        x-checker-data:
+          type: html
+          url: https://www.x.org/releases/individual/lib/
+          url-pattern: (http://some-incorrect.url/libFS-[\d\.]+.tar.bz2)
+          version-pattern: http://some-incorrect.url/libFS-([\d\.]+).tar.bz2


### PR DESCRIPTION
Allow maintainer to provide single `pattern` with two nested match groups to extract pairs `(url, version)`. This makes sorting much more precise, since we don't need to sort urls and always grab corresponding url for version.
Fixes #85 