### PR TITLE
Dockerfile: Install ssh-client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update && \
       python3-toml \
       python3-pyelftools \
       squashfs-tools \
+      ssh-client \
       jq \
     && \
   apt-get clean && \


### PR DESCRIPTION
Commit b700d97a85 changed the Docker image to stop installing apt recommends and with that the image has now stopped pulling ssh-client which broke auth when using git+ssh (as used by the Jenkinsfile/Endless CI integration).

Let's re-add ssh-client manually.