### PR TITLE
Exit with success if PR can be opened

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -294,7 +294,7 @@ def run_with_args(args):
         if args.update or args.commit_only or args.edit_only:
             changes = manifest_checker.update_manifests()
             if args.edit_only:
-                return 0
+                return (outdated_num, True)
             if changes:
                 with indir(os.path.dirname(args.manifest)):
                     subject, body, branch = commit_changes(changes)
@@ -302,13 +302,14 @@ def run_with_args(args):
                         open_pr(
                             subject, body, branch, manifest_checker=manifest_checker
                         )
-                return 0
+                return (outdated_num, True)
 
             log.warning("Can't automatically fix any of the above issues")
 
-    return outdated_num
+    return (outdated_num, False)
 
 
 def main():
-    if run_with_args(parse_cli_args()) > 0:
+    outdated_num, updated = run_with_args(parse_cli_args())
+    if outdated_num > 0 and not updated:
         sys.exit(1)

--- a/src/main.py
+++ b/src/main.py
@@ -294,7 +294,7 @@ def run_with_args(args):
         if args.update or args.commit_only or args.edit_only:
             changes = manifest_checker.update_manifests()
             if args.edit_only:
-                return outdated_num
+                return 0
             if changes:
                 with indir(os.path.dirname(args.manifest)):
                     subject, body, branch = commit_changes(changes)
@@ -302,7 +302,7 @@ def run_with_args(args):
                         open_pr(
                             subject, body, branch, manifest_checker=manifest_checker
                         )
-                return outdated_num
+                return 0
 
             log.warning("Can't automatically fix any of the above issues")
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -38,6 +38,7 @@ class TestEntrypoint(unittest.TestCase):
         return subprocess.run(cmd, cwd=self.test_dir.name, check=True)
 
     def test_full_run(self):
-        args = main.parse_cli_args(["--update", "--commit-only", self.manifest_path])
-        self.assertEqual(main.run_with_args(args), 2)
-        self.assertEqual(main.run_with_args(args), 0)
+        args1 = main.parse_cli_args(["--update", "--commit-only", self.manifest_path])
+        self.assertEqual(main.run_with_args(args1), (2, True))
+        args2 = main.parse_cli_args([self.manifest_path])
+        self.assertEqual(main.run_with_args(args2), (0, False))


### PR DESCRIPTION
Previously, this script would exit(0) if some sources were out of date
but we were able to open a PR to update them. We want this behaviour
because the owner of whatever CI job runs the checker should not get a
failure email if the script opens a PR: that's a success for the
script! The script should only indicate failure if it is not able to
carry out the task it was asked to perform (edit the source tree, open a
PR, etc.).

f4cddf5d12579c39e1fac58f1730d5f553a4c58b changed this behaviour. Change
it back. (I missed this while reviewing that!)

@andrunko noticed this behaviour after #145 merged because the job successfully opened a PR for our Chrome Flatpak but then the Jenkins job still failed.