### PR TITLE
jsonchecker: Get and parse temestamp if provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,9 +206,12 @@ for git type sources, specify tag query and, optionaly, commit and version queri
     "type": "json",
     "url": "https://api.github.com/repos/stedolan/jq/releases/latest",
     "tag-query": ".tag_name",
-    "version-query": "$tag | sub(\"^jq-\"; \"\")"
+    "version-query": "$tag | sub(\"^jq-\"; \"\")",
+    "timestamp-query": ".published_at"
 }
 ```
+
+`timestamp-query` is optional, but if provided - must return a string with timestamp in ISO format.
 
 See the [jq manual](https://stedolan.github.io/jq/manual/) for complete information about writing queries.
 

--- a/src/main.py
+++ b/src/main.py
@@ -69,18 +69,20 @@ def print_outdated_external_data(manifest_checker):
             print(" Has a new version:")
             if data.type == ExternalData.Type.GIT:
                 print(
-                    "  URL:     {url}\n"
-                    "  Commit:  {commit}\n"
-                    "  Tag:     {tag}\n"
-                    "  Branch:  {branch}\n"
-                    "  Version: {version}\n".format(**data.new_version._asdict())
+                    "  URL:       {url}\n"
+                    "  Commit:    {commit}\n"
+                    "  Tag:       {tag}\n"
+                    "  Branch:    {branch}\n"
+                    "  Version:   {version}\n"
+                    "  Timestamp: {timestamp}\n".format(**data.new_version._asdict())
                 )
             else:
                 print(
-                    "  URL:     {url}\n"
-                    "  SHA256:  {checksum}\n"
-                    "  Size:    {size}\n"
-                    "  Version: {version}\n".format(**data.new_version._asdict())
+                    "  URL:       {url}\n"
+                    "  SHA256:    {checksum}\n"
+                    "  Size:      {size}\n"
+                    "  Version:   {version}\n"
+                    "  Timestamp: {timestamp}\n".format(**data.new_version._asdict())
                 )
         elif data.state == ExternalData.State.BROKEN:
             print(" Couldn't get new version for {}".format(data.current_version.url))

--- a/tests/io.github.stedolan.jq.yml
+++ b/tests/io.github.stedolan.jq.yml
@@ -24,3 +24,28 @@ modules:
               url: https://api.github.com/repos/kkos/oniguruma/releases/latest
               tag-query: '.tag_name'
               version-query: '$tag | sub("^[vV]"; "")'
+              timestamp-query: '.published_at'
+
+  - name: yasm
+    sources:
+      - type: git
+        url: https://github.com/yasm/yasm.git
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/yasm/yasm/releases/latest
+          tag-query: '.tag_name'
+          version-query: '.tag_name | sub("^[vV]"; "")'
+
+  - name: tdesktop
+    sources:
+      - type: git
+        url: https://github.com/telegramdesktop/tdesktop.git
+        tag: v2.6.0
+        commit: 740ffb3c6426d62ac1a54e68d5a13f91479baf9a
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/telegramdesktop/tdesktop/releases/latest
+          tag-query: '.tag_name'
+          version-query: '.tag_name | sub("^[vV]"; "")'
+          # This one should result in parse error
+          timestamp-query: '.target_commitish'

--- a/tests/test_jsonchecker.py
+++ b/tests/test_jsonchecker.py
@@ -16,7 +16,7 @@ class TestJSONChecker(unittest.TestCase):
         checker = ManifestChecker(TEST_MANIFEST)
         ext_data = checker.check()
 
-        self.assertEqual(len(ext_data), 2)
+        self.assertEqual(len(ext_data), 4)
         for data in ext_data:
             self.assertIsNotNone(data)
             self.assertIsNotNone(data.new_version)
@@ -48,5 +48,22 @@ class TestJSONChecker(unittest.TestCase):
                     data.new_version.commit, "e03900b038a274ee2f1341039e9003875c11e47d"
                 )
                 self.assertIsNotNone(data.new_version.version)
+                self.assertIsNotNone(data.new_version.timestamp)
+            elif data.filename == "yasm.git":
+                self.assertIsInstance(data.new_version, ExternalGitRef)
+                self.assertEqual(data.current_version.url, data.new_version.url)
+                self.assertIsNotNone(data.new_version.tag)
+                self.assertIsNotNone(data.new_version.commit)
+                self.assertNotEqual(data.new_version.tag, data.current_version.tag)
+                self.assertIsNotNone(data.new_version.version)
+                self.assertIsNone(data.new_version.timestamp)
+            elif data.filename == "tdesktop.git":
+                self.assertIsInstance(data.new_version, ExternalGitRef)
+                self.assertEqual(data.current_version.url, data.new_version.url)
+                self.assertIsNotNone(data.new_version.tag)
+                self.assertIsNotNone(data.new_version.commit)
+                self.assertNotEqual(data.new_version.tag, data.current_version.tag)
+                self.assertIsNotNone(data.new_version.version)
+                self.assertIsNone(data.new_version.timestamp)
             else:
                 self.fail(f"Unhandled data {data.filename}")


### PR DESCRIPTION
Allows using timestamp from JSON APIs. `timestamp-query` must return date in ISO format, should work for GitHub and GitLab.