### PR TITLE
gnomechecker: Support version constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,11 +259,20 @@ Check for latest source tarball for a GNOME project.
 "x-checker-data": {
     "type": "gnome",
     "name": "pygobject",
+    "versions": {
+        "<": "3.38.0"
+    },
     "stable-only": true
 }
 ```
 
 Set `stable-only` to `false` to check for pre-releases, too.
+
+You can also set version constraints in `versions` property (optional).  
+It should contain key-value pairs where key is the comparison operator
+(one of `<`, `>`, `<=`, `>=`, `==`, `!=`), and the value is the version to compare with.
+So, `{"<": "3.38.0", "!=": "3.37.1"}` means *"any version less than 3.38.0 except 3.37.1"*.
+All constraints must match simultaneously, i.e. if one doesn't match - version is rejected.
 
 ### PyPI checker
 

--- a/src/checkers/pypichecker.py
+++ b/src/checkers/pypichecker.py
@@ -44,10 +44,7 @@ class PyPIChecker(Checker):
     def check(self, external_data):
         package_name = external_data.checker_data["name"]
         package_type = external_data.checker_data.get("packagetype", "sdist")
-        if "versions" in external_data.checker_data:
-            constraints = [(o, l) for o, l in external_data.checker_data["versions"]]
-        else:
-            constraints = []
+        constraints = external_data.checker_data.get("versions", {}).items()
 
         with self.session.get(f"{PYPI_INDEX}/{package_name}/json") as response:
             response.raise_for_status()

--- a/tests/com.valvesoftware.Steam.yml
+++ b/tests/com.valvesoftware.Steam.yml
@@ -27,7 +27,7 @@ modules:
           type: pypi
           name: vdf
           versions:
-            - ["==", "3.2"]
+            ==: "3.2"
           packagetype: bdist_wheel
 
 

--- a/tests/org.gnome.baobab.json
+++ b/tests/org.gnome.baobab.json
@@ -29,7 +29,10 @@
                     "x-checker-data": {
                         "type": "gnome",
                         "name": "pygobject",
-                        "stable-only": false
+                        "stable-only": false,
+                        "versions": {
+                            "<": "3.38"
+                        }
                     }
                 }
             ]

--- a/tests/test_gnomechecker.py
+++ b/tests/test_gnomechecker.py
@@ -20,6 +20,7 @@
 
 import os
 import unittest
+from distutils.version import LooseVersion
 
 from src.lib.utils import init_logging
 from src.checker import ManifestChecker
@@ -50,6 +51,9 @@ class TestGNOMEChecker(unittest.TestCase):
                 self._test_stable_only(data)
             elif data.filename == "pygobject-3.36.0.tar.xz":
                 self._test_include_unstable(data)
+                self.assertLess(
+                    LooseVersion(data.new_version.version), LooseVersion("3.38.0")
+                )
             elif data.filename == "alleyoop-0.9.8.tar.xz":
                 self._test_non_standard_version(data)
 


### PR DESCRIPTION
Resolves #157 and opens up a way to add similar version constraints to other checkers.