### PR TITLE
Catch and retry partial read (v2)

### DIFF
--- a/src/checkers/htmlchecker.py
+++ b/src/checkers/htmlchecker.py
@@ -26,6 +26,7 @@ from distutils.version import LooseVersion
 import typing as t
 
 import requests
+import urllib3
 
 from ..lib import utils
 from ..lib.externaldata import ExternalData, Checker
@@ -120,9 +121,8 @@ class HTMLChecker(Checker):
                 latest_url, follow_redirects
             )
         except (
-            requests.exceptions.HTTPError,
-            requests.exceptions.ConnectionError,
-            requests.exceptions.ChunkedEncodingError,
+            urllib3.exceptions.HTTPError,
+            urllib3.exceptions.ConnectionError,
         ) as e:
             log.warning("%s returned %s", latest_url, e)
             external_data.state = ExternalData.State.BROKEN

--- a/src/checkers/urlchecker.py
+++ b/src/checkers/urlchecker.py
@@ -36,7 +36,7 @@ import logging
 import re
 import tempfile
 
-import requests
+import urllib3
 
 from ..lib.externaldata import ExternalData, Checker
 from ..lib import utils
@@ -95,9 +95,8 @@ class URLChecker(Checker):
             else:
                 new_version = utils.get_extra_data_info_from_url(url)
         except (
-            requests.exceptions.HTTPError,
-            requests.exceptions.ConnectionError,
-            requests.exceptions.ChunkedEncodingError,
+            urllib3.exceptions.HTTPError,
+            urllib3.exceptions.ConnectionError,
         ) as e:
             log.warning("%s returned %s", url, e)
             external_data.state = ExternalData.State.BROKEN

--- a/tests/org.externaldatachecker.Manifest.json
+++ b/tests/org.externaldatachecker.Manifest.json
@@ -38,6 +38,17 @@
                 },
                 {
                     "type": "extra-data",
+                    "filename": "relative-redirect.txt",
+                    "url": "https://httpbingo.org/status/404",
+                    "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "size": 0,
+                    "x-checker-data": {
+                        "type": "rotating-url",
+                        "url": "https://httpbingo.org/redirect-to?url=/base64/MzAtNTAgZmVyYWwgaG9ncyEK"
+                    }
+                },
+                {
+                    "type": "extra-data",
                     "filename": "hogs.txt",
                     "url": "https://httpbingo.org/base64/MzAtNTAgZmVyYWwgaG9ncyEK",
                     "sha256": "e4d67702da4eeeb2f15629b65bf6767c028a511839c14ed44d9f34479eaa2b94",

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -36,7 +36,7 @@ TEST_MANIFEST = os.path.join(
 )
 NUM_ARCHIVE_IN_MANIFEST = 1
 NUM_FILE_IN_MANIFEST = 1
-NUM_EXTRA_DATA_IN_MANIFEST = 8
+NUM_EXTRA_DATA_IN_MANIFEST = 9
 NUM_ALL_EXT_DATA = (
     NUM_ARCHIVE_IN_MANIFEST + NUM_FILE_IN_MANIFEST + NUM_EXTRA_DATA_IN_MANIFEST
 )
@@ -284,7 +284,7 @@ modules:
             if data.new_version:
                 ext_data_with_new_version += 1
 
-        self.assertEqual(ext_data_with_new_version, 1)
+        self.assertEqual(ext_data_with_new_version, 2)
 
         file_ext_data = checker.get_external_data(ExternalData.Type.FILE)
         self.assertEqual(len(file_ext_data), NUM_FILE_IN_MANIFEST)
@@ -302,6 +302,18 @@ modules:
         self.assertIsNotNone(dropbox)
         self.assertEqual(dropbox.new_version.version, "64")
         self.assertEqual(dropbox.new_version.url, "https://httpbingo.org/base64/4puE")
+
+        relative_redirect = self._find_by_filename(ext_data, "relative-redirect.txt")
+        self.assertIsNotNone(relative_redirect)
+        self.assertEqual(
+            relative_redirect.new_version.url,
+            "https://httpbingo.org/base64/MzAtNTAgZmVyYWwgaG9ncyEK",
+        )
+        self.assertEqual(
+            relative_redirect.new_version.checksum,
+            "e4d67702da4eeeb2f15629b65bf6767c028a511839c14ed44d9f34479eaa2b94",
+        )
+        self.assertEqual(relative_redirect.new_version.size, 18)
 
         # this URL is a redirect, but since it is not a rotating-url the URL
         # should not be updated.


### PR DESCRIPTION
This is an another attempt of #143, but this time we make sure to return correct URL if there were redirects.
- urllib3 catches incomplete http read (fixes #142)
  - it can't retry incomplete read in streaming mode, so we preload small files to memory and stream only large ones
- explicitly disable content decoding to fix #159 