### PR TITLE
Run checks concurrently

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:bullseye
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -10,6 +10,7 @@ RUN apt-get update && \
       gir1.2-json-1.0 \
       python3-apt \
       python3-defusedxml \
+      python3-aiohttp \
       python3-gi \
       python3-cairo \
       python3-requests \

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ PyGithub
 ruamel.yaml
 toml
 pyelftools
+aiohttp

--- a/src/checkers/anityachecker.py
+++ b/src/checkers/anityachecker.py
@@ -2,8 +2,6 @@ import logging
 import urllib.request
 import urllib.parse
 
-import requests
-
 from ..lib.externaldata import ExternalData, ExternalGitRepo, ExternalGitRef
 from .htmlchecker import HTMLChecker
 
@@ -24,9 +22,8 @@ class AnityaChecker(HTMLChecker):
         stable_only = external_data.checker_data.get("stable-only", False)
 
         query = {"project_id": external_data.checker_data.get("project-id")}
-        with requests.get(versions_url, params=query) as response:
-            response.raise_for_status()
-            result = response.json()
+        async with self.session.get(versions_url, params=query) as response:
+            result = await response.json()
 
         if stable_only:
             latest_version = result["stable_versions"][0]

--- a/src/checkers/anityachecker.py
+++ b/src/checkers/anityachecker.py
@@ -49,7 +49,7 @@ class AnityaChecker(HTMLChecker):
         tag_template = external_data.checker_data["tag-template"]
         latest_tag = self._substitute_placeholders(tag_template, latest_version)
 
-        new_version = ExternalGitRef(
+        new_version = await ExternalGitRef(
             url=external_data.current_version.url,
             commit=None,
             tag=latest_tag,

--- a/src/checkers/anityachecker.py
+++ b/src/checkers/anityachecker.py
@@ -14,7 +14,7 @@ class AnityaChecker(HTMLChecker):
     CHECKER_DATA_TYPE = "anitya"
     SUPPORTED_DATA_CLASSES = [ExternalData, ExternalGitRepo]
 
-    def check(self, external_data):
+    async def check(self, external_data):
         assert self.should_check(external_data)
 
         instance_url = external_data.checker_data.get(
@@ -34,18 +34,18 @@ class AnityaChecker(HTMLChecker):
             latest_version = result["latest_version"]
 
         if isinstance(external_data, ExternalGitRepo):
-            return self._check_git(external_data, latest_version)
-        return self._check_data(external_data, latest_version)
+            return await self._check_git(external_data, latest_version)
+        return await self._check_data(external_data, latest_version)
 
-    def _check_data(self, external_data, latest_version):
+    async def _check_data(self, external_data, latest_version):
         url_template = external_data.checker_data["url-template"]
         latest_url = self._substitute_placeholders(url_template, latest_version)
 
-        self._update_version(
+        await self._update_version(
             external_data, latest_version, latest_url, follow_redirects=False
         )
 
-    def _check_git(self, external_data, latest_version):
+    async def _check_git(self, external_data, latest_version):
         tag_template = external_data.checker_data["tag-template"]
         latest_tag = self._substitute_placeholders(tag_template, latest_version)
 

--- a/src/checkers/debianrepochecker.py
+++ b/src/checkers/debianrepochecker.py
@@ -91,10 +91,7 @@ def _get_timestamp_for_candidate(candidate):
 class DebianRepoChecker(Checker):
     CHECKER_DATA_TYPE = "debian-repo"
 
-    def __init__(self):
-        self._pkgs_cache = {}
-
-    def check(self, external_data):
+    async def check(self, external_data):
         assert self.should_check(external_data)
 
         LOG.debug("Checking %s", external_data.filename)

--- a/src/checkers/gitchecker.py
+++ b/src/checkers/gitchecker.py
@@ -58,7 +58,7 @@ class GitChecker(Checker):
         assert tag_re.groups == 1
 
         matching_tags = []
-        refs = git_ls_remote(external_data.current_version.url)
+        refs = await git_ls_remote(external_data.current_version.url)
         for ref, commit in refs.items():
             if not ref.startswith(REF_TAG_PREFIX):
                 continue
@@ -111,7 +111,7 @@ class GitChecker(Checker):
             return
 
         try:
-            remote_version = external_data.current_version.fetch_remote()
+            remote_version = await external_data.current_version.fetch_remote()
         except KeyError as err:
             log.error(
                 "Couldn't get remote commit from %s: not found %s",

--- a/src/checkers/gitchecker.py
+++ b/src/checkers/gitchecker.py
@@ -42,15 +42,15 @@ class GitChecker(Checker):
     def should_check(self, external_data):
         return isinstance(external_data, ExternalGitRepo)
 
-    def check(self, external_data):
+    async def check(self, external_data):
         assert self.should_check(external_data)
         external_data: ExternalGitRepo
         if external_data.checker_data.get("type") == self.CHECKER_DATA_TYPE:
-            return self._check_has_new(external_data)
-        return self._check_still_valid(external_data)
+            return await self._check_has_new(external_data)
+        return await self._check_still_valid(external_data)
 
     @staticmethod
-    def _check_has_new(external_data):
+    async def _check_has_new(external_data):
         tag_pattern = external_data.checker_data.get(
             "tag-pattern", r"^(?:[vV])?(\d[\d\w.-]+\d)"
         )
@@ -91,7 +91,7 @@ class GitChecker(Checker):
         external_data.set_new_version(new_version)
 
     @staticmethod
-    def _check_still_valid(external_data):
+    async def _check_still_valid(external_data):
         if (
             external_data.current_version.commit is not None
             and external_data.current_version.tag is None

--- a/src/checkers/gnomechecker.py
+++ b/src/checkers/gnomechecker.py
@@ -30,7 +30,7 @@ def _is_stable(version: str) -> bool:
 class GNOMEChecker(Checker):
     CHECKER_DATA_TYPE = "gnome"
 
-    def check(self, external_data):
+    async def check(self, external_data):
         external_data: ExternalData
         project_name = external_data.checker_data["name"]
         stable_only = external_data.checker_data.get("stable-only", True)

--- a/src/checkers/gnomechecker.py
+++ b/src/checkers/gnomechecker.py
@@ -30,9 +30,6 @@ def _is_stable(version: str) -> bool:
 class GNOMEChecker(Checker):
     CHECKER_DATA_TYPE = "gnome"
 
-    def __init__(self):
-        self.session = requests.Session()
-
     def check(self, external_data):
         external_data: ExternalData
         project_name = external_data.checker_data["name"]
@@ -41,9 +38,10 @@ class GNOMEChecker(Checker):
         assert isinstance(project_name, str)
 
         proj_url = urljoin(GNOME_MIRROR, f"sources/{project_name}/")
-        with self.session.get(urljoin(proj_url, "cache.json")) as cache_resp:
-            cache_resp.raise_for_status()
-            cache_json = cache_resp.json()
+        with requests.Session() as session:
+            with session.get(urljoin(proj_url, "cache.json")) as cache_resp:
+                cache_resp.raise_for_status()
+                cache_json = cache_resp.json()
         _, downloads, versions, _ = cache_json
 
         filtered_versions = versions[project_name]
@@ -70,9 +68,10 @@ class GNOMEChecker(Checker):
             for prop in ["tar.xz", "tar.bz2", "tar.gz"]
             if prop in proj_files
         )
-        with self.session.get(urljoin(proj_url, proj_files["sha256sum"])) as cs_resp:
-            cs_resp.raise_for_status()
-            checksums = _parse_checksums(cs_resp.text)
+        with requests.Session() as session:
+            with session.get(urljoin(proj_url, proj_files["sha256sum"])) as cs_resp:
+                cs_resp.raise_for_status()
+                checksums = _parse_checksums(cs_resp.text)
         checksum = checksums[tarball.split("/")[-1]]
 
         new_version = ExternalFile(

--- a/src/checkers/htmlchecker.py
+++ b/src/checkers/htmlchecker.py
@@ -59,7 +59,7 @@ def _get_pattern(checker_data: t.Dict, pattern_name: str):
 class HTMLChecker(Checker):
     CHECKER_DATA_TYPE = "html"
 
-    def check(self, external_data):
+    async def check(self, external_data):
         assert self.should_check(external_data)
 
         url = external_data.checker_data["url"]
@@ -107,7 +107,7 @@ class HTMLChecker(Checker):
 
         abs_url = urllib.parse.urljoin(base=url, url=latest_url)
 
-        self._update_version(external_data, latest_version, abs_url)
+        await self._update_version(external_data, latest_version, abs_url)
 
     @staticmethod
     def _substitute_placeholders(template_string, version):
@@ -124,7 +124,7 @@ class HTMLChecker(Checker):
                 tmpl_vars["patch"] = version_part
         return tmpl.substitute(**tmpl_vars)
 
-    def _update_version(
+    async def _update_version(
         self, external_data, latest_version, latest_url, follow_redirects=False
     ):
         assert latest_version is not None

--- a/src/checkers/htmlchecker.py
+++ b/src/checkers/htmlchecker.py
@@ -26,6 +26,7 @@ from distutils.version import LooseVersion
 import typing as t
 
 import requests
+import aiohttp
 
 from ..lib import utils
 from ..lib.externaldata import ExternalData, Checker
@@ -131,13 +132,14 @@ class HTMLChecker(Checker):
         assert latest_url is not None
 
         try:
-            new_version = utils.get_extra_data_info_from_url(
-                latest_url, follow_redirects
+            new_version = await utils.get_extra_data_info_from_url(
+                latest_url, follow_redirects=follow_redirects, session=self.session
             )
         except (
-            requests.exceptions.HTTPError,
-            requests.exceptions.ConnectionError,
-            requests.exceptions.ChunkedEncodingError,
+            aiohttp.ClientError,
+            aiohttp.ServerConnectionError,
+            aiohttp.ServerDisconnectedError,
+            aiohttp.ServerTimeoutError,
         ) as e:
             log.warning("%s returned %s", latest_url, e)
             external_data.state = ExternalData.State.BROKEN

--- a/src/checkers/htmlchecker.py
+++ b/src/checkers/htmlchecker.py
@@ -25,7 +25,6 @@ from string import Template
 from distutils.version import LooseVersion
 import typing as t
 
-import requests
 import aiohttp
 
 from ..lib import utils
@@ -71,9 +70,8 @@ class HTMLChecker(Checker):
         sort_matches = external_data.checker_data.get("sort-matches", True)
         assert combo_pattern or (version_pattern and (url_pattern or url_template))
 
-        with requests.get(url) as response:
-            response.raise_for_status()
-            html = response.text
+        async with self.session.get(url) as response:
+            html = await response.text()
 
         latest_version: t.Optional[str] = None
         latest_url: t.Optional[str] = None

--- a/src/checkers/jetbrainschecker.py
+++ b/src/checkers/jetbrainschecker.py
@@ -1,8 +1,6 @@
 import datetime
 import logging
 
-import requests
-
 from ..lib.externaldata import ExternalFile, Checker
 
 log = logging.getLogger(__name__)
@@ -20,16 +18,15 @@ class JetBrainsChecker(Checker):
         url = "https://data.services.jetbrains.com/products/releases"
         query = {"code": code, "latest": "true", "type": release_type}
 
-        with requests.get(url, params=query) as response:
-            response.raise_for_status()
-            result = response.json()
+        async with self.session.get(url, params=query) as response:
+            result = await response.json()
             data = result[code][0]
 
         release = data["downloads"]["linux"]
 
-        with requests.get(release["checksumLink"]) as response:
-            response.raise_for_status()
-            checksum = response.text.split(" ")[0]
+        async with self.session.get(release["checksumLink"]) as response:
+            result = await response.text()
+            checksum = result.split(" ")[0]
 
         new_version = ExternalFile(
             release["link"],

--- a/src/checkers/jetbrainschecker.py
+++ b/src/checkers/jetbrainschecker.py
@@ -11,7 +11,7 @@ log = logging.getLogger(__name__)
 class JetBrainsChecker(Checker):
     CHECKER_DATA_TYPE = "jetbrains"
 
-    def check(self, external_data):
+    async def check(self, external_data):
         assert self.should_check(external_data)
 
         code = external_data.checker_data["code"]

--- a/src/checkers/jsonchecker.py
+++ b/src/checkers/jsonchecker.py
@@ -114,6 +114,6 @@ class JSONChecker(HTMLChecker):
         )
 
         if new_version.commit is None:
-            new_version = new_version.fetch_remote()
+            new_version = await new_version.fetch_remote()
 
         external_data.set_new_version(new_version)

--- a/src/checkers/jsonchecker.py
+++ b/src/checkers/jsonchecker.py
@@ -62,7 +62,7 @@ class JSONChecker(HTMLChecker):
     CHECKER_DATA_TYPE = "json"
     SUPPORTED_DATA_CLASSES = [ExternalData, ExternalGitRepo]
 
-    def check(self, external_data):
+    async def check(self, external_data):
         assert self.should_check(external_data)
 
         json_url = external_data.checker_data["url"]
@@ -71,11 +71,11 @@ class JSONChecker(HTMLChecker):
             json_data = response.content
 
         if isinstance(external_data, ExternalGitRepo):
-            return self._check_git(json_data, external_data)
+            return await self._check_git(json_data, external_data)
         else:
-            return self._check_data(json_data, external_data)
+            return await self._check_data(json_data, external_data)
 
-    def _check_data(self, json_data: str, external_data: ExternalData):
+    async def _check_data(self, json_data: str, external_data: ExternalData):
         checker_data = external_data.checker_data
         results = query_sequence(
             json_data,
@@ -89,11 +89,11 @@ class JSONChecker(HTMLChecker):
         latest_version = results["version"]
         latest_url = results["url"]
 
-        self._update_version(
+        await self._update_version(
             external_data, latest_version, latest_url, follow_redirects=False
         )
 
-    def _check_git(self, json_data: str, external_data: ExternalGitRepo):
+    async def _check_git(self, json_data: str, external_data: ExternalGitRepo):
         checker_data = external_data.checker_data
         results = query_sequence(
             json_data,

--- a/src/checkers/pypichecker.py
+++ b/src/checkers/pypichecker.py
@@ -3,8 +3,6 @@ from datetime import datetime
 import re
 import typing as t
 
-import requests
-
 from ..lib.externaldata import Checker, ExternalFile
 from ..lib.utils import filter_versions
 
@@ -43,10 +41,8 @@ class PyPIChecker(Checker):
         package_type = external_data.checker_data.get("packagetype", "sdist")
         constraints = external_data.checker_data.get("versions", {}).items()
 
-        with requests.Session() as session:
-            with session.get(f"{PYPI_INDEX}/{package_name}/json") as response:
-                response.raise_for_status()
-                pypi_data = response.json()
+        async with self.session.get(f"{PYPI_INDEX}/{package_name}/json") as response:
+            pypi_data = await response.json()
 
         if constraints:
             releases = pypi_data["releases"]

--- a/src/checkers/pypichecker.py
+++ b/src/checkers/pypichecker.py
@@ -38,7 +38,7 @@ def _filter_downloads(
 class PyPIChecker(Checker):
     CHECKER_DATA_TYPE = "pypi"
 
-    def check(self, external_data):
+    async def check(self, external_data):
         package_name = external_data.checker_data["name"]
         package_type = external_data.checker_data.get("packagetype", "sdist")
         constraints = external_data.checker_data.get("versions", {}).items()

--- a/src/checkers/pypichecker.py
+++ b/src/checkers/pypichecker.py
@@ -38,17 +38,15 @@ def _filter_downloads(
 class PyPIChecker(Checker):
     CHECKER_DATA_TYPE = "pypi"
 
-    def __init__(self):
-        self.session = requests.Session()
-
     def check(self, external_data):
         package_name = external_data.checker_data["name"]
         package_type = external_data.checker_data.get("packagetype", "sdist")
         constraints = external_data.checker_data.get("versions", {}).items()
 
-        with self.session.get(f"{PYPI_INDEX}/{package_name}/json") as response:
-            response.raise_for_status()
-            pypi_data = response.json()
+        with requests.Session() as session:
+            with session.get(f"{PYPI_INDEX}/{package_name}/json") as response:
+                response.raise_for_status()
+                pypi_data = response.json()
 
         if constraints:
             releases = pypi_data["releases"]

--- a/src/checkers/rustchecker.py
+++ b/src/checkers/rustchecker.py
@@ -16,7 +16,7 @@ VERSION_RE = re.compile(r"^(\S+)\s+\((\S+)\s+(\S+)\)")
 class RustChecker(Checker):
     CHECKER_DATA_TYPE = "rust"
 
-    def check(self, external_data):
+    async def check(self, external_data):
         assert self.should_check(external_data)
 
         channel = external_data.checker_data.get("channel", "stable")

--- a/src/checkers/rustchecker.py
+++ b/src/checkers/rustchecker.py
@@ -3,7 +3,6 @@ import logging
 import re
 
 import toml
-import requests
 
 from ..lib.externaldata import ExternalFile, Checker
 
@@ -25,9 +24,8 @@ class RustChecker(Checker):
 
         url = f"https://static.rust-lang.org/dist/channel-rust-{channel}.toml"
 
-        with requests.get(url) as response:
-            response.raise_for_status()
-            data = toml.loads(response.text)
+        async with self.session.get(url) as response:
+            data = toml.loads(await response.text())
 
         package = data["pkg"][package_name]
         target = package["target"][target_name]

--- a/src/checkers/snapcraftchecker.py
+++ b/src/checkers/snapcraftchecker.py
@@ -31,7 +31,7 @@ class SnapcraftChecker(Checker):
         if sha3.hexdigest() == sha3_384:
             return sha2.hexdigest()
 
-    def check(self, external_data):
+    async def check(self, external_data):
         assert self.should_check(external_data)
 
         name = external_data.checker_data["name"]

--- a/src/checkers/snapcraftchecker.py
+++ b/src/checkers/snapcraftchecker.py
@@ -1,6 +1,4 @@
-import urllib.request
 import datetime
-import json
 import logging
 import hashlib
 
@@ -15,18 +13,15 @@ class SnapcraftChecker(Checker):
     _arches = {"x86_64": "amd64", "aarch64": "arm64", "arm": "armhf", "i386": "i386"}
     _BLOCK_SIZE = 65536
 
-    def _get_sha256(self, url: str, sha3_384: str):
-        req = urllib.request.Request(url)
-        resp = urllib.request.urlopen(req)
-
+    async def _get_sha256(self, url: str, sha3_384: str):
+        assert self.session is not None
         sha2 = hashlib.sha256()
         sha3 = hashlib.sha3_384()
 
-        data = resp.read(self._BLOCK_SIZE)
-        while data:
-            sha2.update(data)
-            sha3.update(data)
-            data = resp.read(self._BLOCK_SIZE)
+        async with self.session.get(url) as response:
+            async for data in response.content.iter_chunked(self._BLOCK_SIZE):
+                sha2.update(data)
+                sha3.update(data)
 
         if sha3.hexdigest() == sha3_384:
             return sha2.hexdigest()
@@ -40,12 +35,8 @@ class SnapcraftChecker(Checker):
         url = f"http://api.snapcraft.io/v2/snaps/info/{name}"
         header = {"Snap-Device-Series": "16"}
 
-        req = urllib.request.Request(url, headers=header)
-
-        log.debug("Getting extra data info from %s", url)
-        resp = urllib.request.urlopen(req)
-
-        js = json.load(resp)
+        async with self.session.get(url, headers=header) as response:
+            js = await response.json()
 
         data = [
             x
@@ -56,7 +47,7 @@ class SnapcraftChecker(Checker):
 
         if external_data.current_version.url != data["download"]["url"]:
             log.debug("Downloading file from %s; may take a while", url)
-            sha256 = self._get_sha256(
+            sha256 = await self._get_sha256(
                 data["download"]["url"], data["download"]["sha3-384"]
             )
 

--- a/src/checkers/urlchecker.py
+++ b/src/checkers/urlchecker.py
@@ -67,7 +67,7 @@ class URLChecker(Checker):
     def should_check(self, external_data):
         return isinstance(external_data, ExternalData)
 
-    def check(self, external_data):
+    async def check(self, external_data):
         assert self.should_check(external_data)
 
         is_rotating = external_data.checker_data.get("type") == self.CHECKER_DATA_TYPE

--- a/src/lib/externaldata.py
+++ b/src/lib/externaldata.py
@@ -249,14 +249,14 @@ class ExternalGitRef(t.NamedTuple):
             return annotated_tag_commit
         raise KeyError(f"refs/tags/{tag}")
 
-    def fetch_remote(self) -> ExternalGitRef:
+    async def fetch_remote(self) -> ExternalGitRef:
         log.debug(
             "Retrieving commit from %s tag %s branch %s",
             self.url,
             self.tag,
             self.branch,
         )
-        refs = utils.git_ls_remote(self.url)
+        refs = await utils.git_ls_remote(self.url)
 
         if self.tag is not None:
             got_commit = self._get_tagged_commit(refs, self.tag)

--- a/src/main.py
+++ b/src/main.py
@@ -29,6 +29,7 @@ import logging
 import os
 import subprocess
 import sys
+import asyncio
 
 from github import Github
 
@@ -282,13 +283,13 @@ def parse_cli_args(cli_args=None):
     return parser.parse_args(cli_args)
 
 
-def run_with_args(args):
+async def run_with_args(args):
     init_logging(logging.DEBUG if args.verbose else logging.INFO)
 
     manifest_checker = checker.ManifestChecker(args.manifest)
     filter_type = ExternalData.TYPES.get(args.filter_type)
 
-    manifest_checker.check(filter_type)
+    await manifest_checker.check(filter_type)
 
     outdated_num = print_outdated_external_data(manifest_checker)
 
@@ -312,6 +313,6 @@ def run_with_args(args):
 
 
 def main():
-    outdated_num, updated = run_with_args(parse_cli_args())
+    outdated_num, updated = asyncio.run(run_with_args(parse_cli_args()))
     if outdated_num > 0 and not updated:
         sys.exit(1)

--- a/tests/test_anytiachecker.py
+++ b/tests/test_anytiachecker.py
@@ -8,13 +8,13 @@ from src.lib.utils import init_logging
 TEST_MANIFEST = os.path.join(os.path.dirname(__file__), "org.flatpak.Flatpak.yml")
 
 
-class TestAnityaChecker(unittest.TestCase):
+class TestAnityaChecker(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         init_logging()
 
-    def test_check(self):
+    async def test_check(self):
         checker = ManifestChecker(TEST_MANIFEST)
-        ext_data = checker.check()
+        ext_data = await checker.check()
 
         self.assertEqual(len(ext_data), 4)
         for data in ext_data:

--- a/tests/test_debianrepochecker.py
+++ b/tests/test_debianrepochecker.py
@@ -9,13 +9,13 @@ TEST_MANIFEST = os.path.join(
 )
 
 
-class TestDebianRepoChecker(unittest.TestCase):
+class TestDebianRepoChecker(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         init_logging()
 
-    def test_check(self):
+    async def test_check(self):
         checker = ManifestChecker(TEST_MANIFEST)
-        ext_data = checker.check()
+        ext_data = await checker.check()
         for data in ext_data:
             self.assertIsNotNone(data)
             self.assertIsNotNone(data.new_version)

--- a/tests/test_gitchecker.py
+++ b/tests/test_gitchecker.py
@@ -10,7 +10,7 @@ from src.checkers.gitchecker import TagWithVersion
 TEST_MANIFEST = os.path.join(os.path.dirname(__file__), "com.virustotal.Uploader.yml")
 
 
-class TestGitChecker(unittest.TestCase):
+class TestGitChecker(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         init_logging()
 
@@ -27,9 +27,9 @@ class TestGitChecker(unittest.TestCase):
             sorted([t1, t1a, t3, t3a, t2], reverse=True), sorted_tags[::-1]
         )
 
-    def test_check_and_update(self):
+    async def test_check_and_update(self):
         checker = ManifestChecker(TEST_MANIFEST)
-        ext_data = checker.check()
+        ext_data = await checker.check()
 
         self.assertEqual(len(ext_data), 8)
         for data in ext_data:

--- a/tests/test_gnomechecker.py
+++ b/tests/test_gnomechecker.py
@@ -28,13 +28,13 @@ from src.checker import ManifestChecker
 TEST_MANIFEST = os.path.join(os.path.dirname(__file__), "org.gnome.baobab.json")
 
 
-class TestGNOMEChecker(unittest.TestCase):
+class TestGNOMEChecker(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         init_logging()
 
-    def test_check(self):
+    async def test_check(self):
         checker = ManifestChecker(TEST_MANIFEST)
-        ext_data = checker.check()
+        ext_data = await checker.check()
 
         for data in ext_data:
             self.assertIsNotNone(data.new_version)

--- a/tests/test_htmlchecker.py
+++ b/tests/test_htmlchecker.py
@@ -30,13 +30,13 @@ from src.checker import ManifestChecker
 TEST_MANIFEST = os.path.join(os.path.dirname(__file__), "org.x.xeyes.yml")
 
 
-class TestHTMLChecker(unittest.TestCase):
+class TestHTMLChecker(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         init_logging()
 
-    def test_check(self):
+    async def test_check(self):
         checker = ManifestChecker(TEST_MANIFEST)
-        ext_data = checker.check()
+        ext_data = await checker.check()
         self._test_separate_patterns(
             self._find_by_filename(ext_data, "xeyes-1.1.0.tar.bz2")
         )

--- a/tests/test_jetbrainschecker.py
+++ b/tests/test_jetbrainschecker.py
@@ -7,13 +7,13 @@ from src.lib.utils import init_logging
 TEST_MANIFEST = os.path.join(os.path.dirname(__file__), "com.jetbrains.PhpStorm.json")
 
 
-class TestJetBrainsChecker(unittest.TestCase):
+class TestJetBrainsChecker(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         init_logging()
 
-    def test_check(self):
+    async def test_check(self):
         checker = ManifestChecker(TEST_MANIFEST)
-        ext_data = checker.check()
+        ext_data = await checker.check()
 
         data = self._find_by_filename(ext_data, "phpstorm.tar.gz")
         self.assertIsNotNone(data)

--- a/tests/test_jsonchecker.py
+++ b/tests/test_jsonchecker.py
@@ -8,13 +8,13 @@ from src.lib.externaldata import ExternalFile, ExternalGitRef
 TEST_MANIFEST = os.path.join(os.path.dirname(__file__), "io.github.stedolan.jq.yml")
 
 
-class TestJSONChecker(unittest.TestCase):
+class TestJSONChecker(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         init_logging()
 
-    def test_check(self):
+    async def test_check(self):
         checker = ManifestChecker(TEST_MANIFEST)
-        ext_data = checker.check()
+        ext_data = await checker.check()
 
         self.assertEqual(len(ext_data), 4)
         for data in ext_data:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -15,7 +15,7 @@ TEST_APPDATA = os.path.join(
 )
 
 
-class TestEntrypoint(unittest.TestCase):
+class TestEntrypoint(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         self.test_dir = tempfile.TemporaryDirectory()
         self.manifest_filename = os.path.basename(TEST_MANIFEST)
@@ -37,8 +37,8 @@ class TestEntrypoint(unittest.TestCase):
     def _run_cmd(self, cmd):
         return subprocess.run(cmd, cwd=self.test_dir.name, check=True)
 
-    def test_full_run(self):
+    async def test_full_run(self):
         args1 = main.parse_cli_args(["--update", "--commit-only", self.manifest_path])
-        self.assertEqual(main.run_with_args(args1), (2, True))
+        self.assertEqual(await main.run_with_args(args1), (2, True))
         args2 = main.parse_cli_args([self.manifest_path])
-        self.assertEqual(main.run_with_args(args2), (0, False))
+        self.assertEqual(await main.run_with_args(args2), (0, False))

--- a/tests/test_pypichecker.py
+++ b/tests/test_pypichecker.py
@@ -7,13 +7,13 @@ from src.lib.utils import init_logging
 TEST_MANIFEST = os.path.join(os.path.dirname(__file__), "com.valvesoftware.Steam.yml")
 
 
-class TestPyPIChecker(unittest.TestCase):
+class TestPyPIChecker(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         init_logging()
 
-    def test_check(self):
+    async def test_check(self):
         checker = ManifestChecker(TEST_MANIFEST)
-        ext_data = checker.check()
+        ext_data = await checker.check()
 
         self.assertEqual(len(ext_data), 4)
         for data in ext_data:

--- a/tests/test_rustchecker.py
+++ b/tests/test_rustchecker.py
@@ -9,13 +9,13 @@ TEST_MANIFEST = os.path.join(
 )
 
 
-class TestRustChecker(unittest.TestCase):
+class TestRustChecker(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         init_logging()
 
-    def test_check(self):
+    async def test_check(self):
         checker = ManifestChecker(TEST_MANIFEST)
-        ext_data = checker.check()
+        ext_data = await checker.check()
 
         self.assertEqual(len(ext_data), 1)
         data = ext_data[0]

--- a/tests/test_snapcraftchecker.py
+++ b/tests/test_snapcraftchecker.py
@@ -7,13 +7,13 @@ from src.lib.utils import init_logging
 TEST_MANIFEST = os.path.join(os.path.dirname(__file__), "com.nordpass.NordPass.yaml")
 
 
-class TestSnapctaftChecker(unittest.TestCase):
+class TestSnapctaftChecker(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         init_logging()
 
-    def test_check(self):
+    async def test_check(self):
         checker = ManifestChecker(TEST_MANIFEST)
-        ext_data = checker.check()
+        ext_data = await checker.check()
 
         data = self._find_by_filename(ext_data, "nordpass.snap")
         self.assertIsNotNone(data)

--- a/tests/test_urlchecker.py
+++ b/tests/test_urlchecker.py
@@ -7,13 +7,13 @@ from src.lib.utils import init_logging
 TEST_MANIFEST = os.path.join(os.path.dirname(__file__), "com.unity.UnityHub.yaml")
 
 
-class TestURLChecker(unittest.TestCase):
+class TestURLChecker(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         init_logging()
 
-    def test_check(self):
+    async def test_check(self):
         checker = ManifestChecker(TEST_MANIFEST)
-        ext_data = checker.check()
+        ext_data = await checker.check()
 
         data = self._find_by_filename(ext_data, "UnityHubSetup.AppImage")
         self.assertIsNotNone(data)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -20,6 +20,7 @@
 import unittest
 import subprocess
 import os
+import asyncio
 
 from src.lib.utils import parse_github_url, strip_query, clear_env, filter_versions
 
@@ -59,13 +60,21 @@ class TestStripQuery(unittest.TestCase):
         self.assertEqual(strip_query(url), expected)
 
 
-class TestClearEnv(unittest.TestCase):
+class TestClearEnv(unittest.IsolatedAsyncioTestCase):
     def test_clear_env(self):
         os.environ["SOME_TOKEN_HERE"] = "leaked"
         # pylint: disable=subprocess-run-check
         proc = subprocess.run(
             'test -z "$SOME_TOKEN_HERE"', shell=True, env=clear_env(os.environ)
         )
+        self.assertEqual(proc.returncode, 0)
+
+    async def test_clear_env_async(self):
+        os.environ["SOME_TOKEN_HERE"] = "leaked"
+        proc = await asyncio.create_subprocess_shell(
+            'test -z "$SOME_TOKEN_HERE"', env=clear_env(os.environ)
+        )
+        await proc.wait()
         self.assertEqual(proc.returncode, 0)
 
 


### PR DESCRIPTION
f-e-d-c downloads a lot of data from remote sources. Doing this sequentially, waiting on each transfer, is rather slow.
This PR makes (almost) all network I/O non-blocking with help of `asyncio` and `aiohttp`, downloading files concurrently and drastically reducing check times for app manifests with multiple modules.
For example, Steam (25 data items) check time goes down from 17 to 3 seconds (on my machine).

Changes include:
- Update Debian image to bullseye (asyncio in python 3.5 is way too old)
- Add context manager to checker class
  - set up aiohttp session per checker instance
  - create checker instance right before applying it, one per data item
- Split out individual data check to separate method; these are ran concurrently
- Make `git ls-remote` calls async, so these are not blocking, too
- Do new upstream version checks (HTTP API calls and such) in checkers with aiohttp, too

Using aiohttp fixes #142. Using newer ruamel.yaml seems to fix #132.