### PR TITLE
chromiumchecker: Add checker for Chromium components

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ data in Flatpak manifests.
     - [JetBrains checker](#jetbrains-checker)
     - [Snapcraft checker](#snapcraft-checker)
     - [Rust checker](#rust-checker)
+    - [Chromium checker](#chromium-checker)
 - [License and Copyright](#license-and-copyright)
 
 ## Motivation
@@ -354,6 +355,29 @@ for [Rust](https://www.rust-lang.org/):
     "target": "target triple, for example: x86_64-unknown-linux-gnu"
 }
 ```
+
+### Chromium checker
+
+Special checker that will check for available updates to the
+[Chromium](https://www.chromium.org/) tarballs, as well as the toolchain
+binaries or sources used to build it.
+
+```json
+"x-checker-data": {
+    "type": "chromium",
+    "component": "chromium, llvm-prebuilt, or llvm-git; defaults to chromium"
+}
+```
+
+The following components are supported:
+
+- `chromium`: updates the Chromium tarball itself, used on URL-based sources
+  (e.g. `type: archive`).
+- `llvm-prebuilt`: updates a tarball pointing to the official LLVM prebuilt
+  toolchain archive matching the latest Chromium version. Used on URL-based
+  sources.
+- `llvm-git`: updates a `type: git` source for its commit to point to the LLVM
+  sources for the toolchain used by the latest Chromium version.
 
 ## License and Copyright
 

--- a/src/checkers/__init__.py
+++ b/src/checkers/__init__.py
@@ -9,6 +9,7 @@ from .rustchecker import RustChecker
 from .gitchecker import GitChecker
 from .pypichecker import PyPIChecker
 from .gnomechecker import GNOMEChecker
+from .chromiumchecker import ChromiumChecker
 
 
 # For each ExternalData, checkers are run in the order listed here, stopping once data.state is
@@ -23,6 +24,7 @@ ALL_CHECKERS = [
     JSONChecker,
     PyPIChecker,
     GNOMEChecker,
+    ChromiumChecker,
     GitChecker,  # leave this last but one
     URLChecker,  # leave this last
 ]

--- a/tests/org.chromium.Chromium.yaml
+++ b/tests/org.chromium.Chromium.yaml
@@ -1,0 +1,23 @@
+app-id: org.chromium.Chromium
+modules:
+  - name: chromium
+    sources:
+      - type: archive
+        url: https://commondatastorage.googleapis.com/chromium-browser-official/chromium-90.0.4430.212.tar.xz
+        sha256: abe11d0cb1ff21278aad2eec1a1e279d59176b15331804d7df1807446786d59e
+        x-checker-data:
+          type: chromium
+          component: chromium
+          is-main-source: true
+      - type: archive
+        url: https://commondatastorage.googleapis.com/chromium-browser-clang/Linux_x64/clang-llvmorg-13-init-1559-g01b87444-3.tgz
+        sha256: 676448e180fb060d3983f24476a2136eac83c6011c600117686035634a2bbe26
+        x-checker-data:
+          type: chromium
+          component: llvm-prebuilt
+      - type: git
+        url: https://github.com/llvm/llvm-project
+        commit: 01b87444cb02c38147dccc7049b32675de860d47
+        x-checker-data:
+          type: chromium
+          component: llvm-git

--- a/tests/test_chromiumchecker.py
+++ b/tests/test_chromiumchecker.py
@@ -1,0 +1,66 @@
+import logging
+import os
+import unittest
+from distutils.version import LooseVersion
+
+from src.checker import ManifestChecker
+from src.lib.externaldata import (
+    ExternalDataSource,
+    ExternalFile,
+    ExternalGitRef,
+    ExternalGitRepo,
+)
+from src.lib.utils import init_logging
+
+TEST_MANIFEST = os.path.join(os.path.dirname(__file__), "org.chromium.Chromium.yaml")
+
+
+class TestChromiumChecker(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        init_logging(logging.INFO)
+
+    async def test_check(self):
+        checker = ManifestChecker(TEST_MANIFEST)
+        ext_data = await checker.check()
+
+        self.assertEqual(len(ext_data), 3)
+        for data in ext_data:
+            self.assertIsNotNone(data.new_version)
+            self.assertIsNotNone(data.new_version.version)
+            self.assertGreater(
+                LooseVersion(data.new_version.version), LooseVersion("90.0.4430.212")
+            )
+
+            if isinstance(data, ExternalDataSource):
+                self.assertIsInstance(data.new_version, ExternalFile)
+                self.assertIsNotNone(data.new_version.checksum)
+                self.assertIsInstance(data.new_version.checksum, str)
+                if data.filename.startswith("chromium-"):
+                    self.assertRegex(
+                        data.new_version.url,
+                        r"^https://commondatastorage.googleapis.com/chromium-browser-official/chromium-[\d.]+\.tar\.xz$",
+                    )
+                    self.assertNotEqual(
+                        data.new_version.checksum,
+                        "abe11d0cb1ff21278aad2eec1a1e279d59176b15331804d7df1807446786d59e",
+                    )
+                elif data.filename.startswith("clang-"):
+                    self.assertRegex(
+                        data.new_version.url,
+                        r"^https://commondatastorage.googleapis.com/chromium-browser-clang/Linux_x64/clang-.*\.tgz$",
+                    )
+                    self.assertNotEqual(
+                        data.new_version.checksum,
+                        "676448e180fb060d3983f24476a2136eac83c6011c600117686035634a2bbe26",
+                    )
+                else:
+                    self.fail(f"unexpected extra-data filename {data.filename}")
+            elif isinstance(data, ExternalGitRepo):
+                self.assertEqual(data.filename, "llvm-project")
+                self.assertIsInstance(data.new_version, ExternalGitRef)
+                self.assertIsNotNone(data.new_version.commit)
+                self.assertNotEqual(
+                    data.new_version.commit, data.current_version.commit
+                )
+            else:
+                self.fail(repr(type(data)))


### PR DESCRIPTION
This is needed to be able to auto-update the versions for the LLVM toolchain components in sync with Chromium itself. It also can update the Chromium tarball; the Anitya checker could already technically do this, but this code needs to parse the versions anyway, so actually updating the tarball in sync is a minor addition.