### PR TITLE
chromiumchecker: Don't attempt to resolve commits

### DIFF
--- a/src/checkers/chromiumchecker.py
+++ b/src/checkers/chromiumchecker.py
@@ -116,14 +116,14 @@ class LLVMGitComponent(LLVMComponent):
 
         llvm_version = await self.get_llvm_version()
 
-        new_version = await ExternalGitRef(
+        new_version = ExternalGitRef(
             url=self.external_data.current_version.url,
             commit=llvm_version.revision,
             tag=None,
             branch=None,
             version=self.latest_version,
             timestamp=None,
-        ).fetch_remote()
+        )
         self.external_data.set_new_version(new_version)
 
 


### PR DESCRIPTION
At the time of writing, I didn't realize fetch_remote() actually is
intended to find the commit value of a tag or branch; if neither is
given, it assumes you want the master branch. In other words, this would
end up discarding the commit revision that it was given and just grab
LLVM head.