### PR TITLE
chromiumchecker: Use NotImplementedError exception

### DIFF
--- a/src/checkers/chromiumchecker.py
+++ b/src/checkers/chromiumchecker.py
@@ -34,7 +34,7 @@ class Component:
         assert latest_version is not None
 
     async def check(self) -> None:
-        raise NotImplemented
+        raise NotImplementedError
 
     async def update_external_source_version(self, latest_url):
         assert latest_url is not None


### PR DESCRIPTION
NotImplemented is not an exception
This was caught by https://lgtm.com/projects/g/flathub/flatpak-external-data-checker/alerts/