### PR TITLE
Refactor: Drop `External{Data,GitRepo}Source` classes

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,7 @@
 [run]
 source = src
+
+[report]
+exclude_lines =
+    pragma: no cover
+    raise NotImplementedError

--- a/src/checker.py
+++ b/src/checker.py
@@ -29,7 +29,6 @@ from .checkers import ALL_CHECKERS
 from .lib.appdata import add_release_to_file
 from .lib.externaldata import (
     ExternalData,
-    ExternalDataSource,
     ExternalGitRepo,
     ExternalFile,
     ExternalGitRef,
@@ -176,7 +175,7 @@ class ManifestChecker:
         sources = module.get("sources", [])
 
         manifest_datas = self._external_data.setdefault(module_path, [])
-        module_datas = ExternalDataSource.from_sources(module_path, sources)
+        module_datas = ExternalData.from_sources(module_path, sources)
         manifest_datas.extend(module_datas)
 
         for sp in filter(lambda s: _external_source_filter(module_path, s), sources):
@@ -192,7 +191,7 @@ class ManifestChecker:
                 external_sources = [external_manifest]
             else:
                 raise TypeError(f"Invalid data type in {external_source_path}")
-            external_source_datas = ExternalDataSource.from_sources(
+            external_source_datas = ExternalData.from_sources(
                 external_source_path, external_sources
             )
             self._external_data[external_source_path] = external_source_datas

--- a/src/checkers/chromiumchecker.py
+++ b/src/checkers/chromiumchecker.py
@@ -8,7 +8,6 @@ from ..lib.externaldata import (
     Checker,
     ExternalBase,
     ExternalData,
-    ExternalDataSource,
     ExternalGitRepo,
     ExternalGitRef,
 )
@@ -58,7 +57,7 @@ class Component:
 
 class ChromiumComponent(Component):
     NAME = "chromium"
-    DATA_CLASS = ExternalDataSource
+    DATA_CLASS = ExternalData
 
     _URL_FORMAT = (
         "https://commondatastorage.googleapis.com"
@@ -66,7 +65,7 @@ class ChromiumComponent(Component):
     )
 
     async def check(self) -> None:
-        assert isinstance(self.external_data, ExternalDataSource)
+        assert isinstance(self.external_data, ExternalData)
 
         latest_url = self._URL_FORMAT.format(version=self.latest_version)
         await self.update_external_source_version(latest_url)
@@ -129,7 +128,7 @@ class LLVMGitComponent(LLVMComponent):
 
 class LLVMPrebuiltComponent(LLVMComponent):
     NAME = "llvm-prebuilt"
-    DATA_CLASS = ExternalDataSource
+    DATA_CLASS = ExternalData
 
     _PREBUILT_URL_FORMAT = (
         "https://commondatastorage.googleapis.com"
@@ -137,7 +136,7 @@ class LLVMPrebuiltComponent(LLVMComponent):
     )
 
     async def check(self) -> None:
-        assert isinstance(self.external_data, ExternalDataSource)
+        assert isinstance(self.external_data, ExternalData)
 
         llvm_version = await self.get_llvm_version()
 

--- a/tests/test_chromiumchecker.py
+++ b/tests/test_chromiumchecker.py
@@ -5,7 +5,7 @@ from distutils.version import LooseVersion
 
 from src.checker import ManifestChecker
 from src.lib.externaldata import (
-    ExternalDataSource,
+    ExternalData,
     ExternalFile,
     ExternalGitRef,
     ExternalGitRepo,
@@ -31,7 +31,7 @@ class TestChromiumChecker(unittest.IsolatedAsyncioTestCase):
                 LooseVersion(data.new_version.version), LooseVersion("90.0.4430.212")
             )
 
-            if isinstance(data, ExternalDataSource):
+            if isinstance(data, ExternalData):
                 self.assertIsInstance(data.new_version, ExternalFile)
                 self.assertIsNotNone(data.new_version.checksum)
                 self.assertIsInstance(data.new_version.checksum, str)


### PR DESCRIPTION
Since we don't explicitly distinguish between `ExternalData` and `ExternalDataSource` objects anywhere, these subclasses are redundant. The logic of creating an `ExternalData` object from flatpak-builder source can be moved from the subclass `__init__` method to a parent class method.

With this changes, `from_source()` method serves as a "router" that selects appropriate class for given source, and calls that class' `from_source_impl()` method which should return the resulting object.