### PR TITLE
Support different checksums

### DIFF
--- a/src/checkers/gnomechecker.py
+++ b/src/checkers/gnomechecker.py
@@ -6,6 +6,7 @@ from yarl import URL
 
 from ..lib import OPERATORS_SCHEMA
 from ..lib.externaldata import Checker, ExternalBase, ExternalFile
+from ..lib.checksums import MultiDigest
 from ..lib.utils import filter_versions
 
 log = logging.getLogger(__name__)
@@ -88,7 +89,7 @@ class GNOMEChecker(Checker):
 
         new_version = ExternalFile(
             url=str(proj_url / tarball_path),
-            checksum=checksum,
+            checksum=MultiDigest(sha256=checksum),
             size=None,
             version=latest_version,
             timestamp=None,

--- a/src/checkers/jetbrainschecker.py
+++ b/src/checkers/jetbrainschecker.py
@@ -2,6 +2,7 @@ import datetime
 import logging
 
 from ..lib.externaldata import ExternalBase, ExternalFile, Checker
+from ..lib.checksums import MultiDigest
 
 log = logging.getLogger(__name__)
 
@@ -39,7 +40,7 @@ class JetBrainsChecker(Checker):
 
         new_version = ExternalFile(
             url=release["link"],
-            checksum=checksum,
+            checksum=MultiDigest(sha256=checksum),
             size=release["size"],
             version=data["version"],
             timestamp=datetime.datetime.strptime(data["date"], "%Y-%m-%d"),

--- a/src/checkers/pypichecker.py
+++ b/src/checkers/pypichecker.py
@@ -5,6 +5,7 @@ import typing as t
 
 from ..lib import OPERATORS_SCHEMA
 from ..lib.externaldata import Checker, ExternalFile, ExternalBase
+from ..lib.checksums import MultiDigest
 from ..lib.utils import filter_versions
 from ..lib.errors import CheckerQueryError
 
@@ -69,9 +70,11 @@ class PyPIChecker(Checker):
                 f"Couldn't find {package_type} for package {package_name}"
             ) from err
 
+        checksum = MultiDigest.from_source(pypi_download["digests"])
+
         new_version = ExternalFile(
             url=pypi_download["url"],
-            checksum=pypi_download["digests"]["sha256"],
+            checksum=checksum,
             size=pypi_download["size"],
             version=pypi_version,
             timestamp=pypi_date,

--- a/src/checkers/rustchecker.py
+++ b/src/checkers/rustchecker.py
@@ -5,6 +5,7 @@ import re
 import toml
 
 from ..lib.externaldata import ExternalBase, ExternalFile, Checker
+from ..lib.checksums import MultiDigest
 
 log = logging.getLogger(__name__)
 
@@ -51,7 +52,7 @@ class RustChecker(Checker):
         if target["available"]:
             new_version = ExternalFile(
                 url=target["xz_url"],
-                checksum=target["xz_hash"],
+                checksum=MultiDigest(sha256=target["xz_hash"]),
                 size=None,
                 version=appstream_version,
                 timestamp=release_date,

--- a/src/lib/checksums.py
+++ b/src/lib/checksums.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import hashlib
+import logging
+import typing as t
+
+from .errors import SourceUpdateError
+
+
+log = logging.getLogger(__name__)
+
+
+class MultiDigest(t.NamedTuple):
+    md5: t.Optional[str] = None
+    sha1: t.Optional[str] = None
+    sha256: t.Optional[str] = None
+    sha512: t.Optional[str] = None
+
+    @classmethod
+    def from_source(cls, source: t.Dict) -> MultiDigest:
+        # pylint: disable=no-member
+        digests = {k: source[k] for k in cls._fields if k in source}
+        assert digests, source
+        return cls(**digests)
+
+    def __eq__(self, other):
+        assert isinstance(other, type(self)), other
+        # Iterate digest types from strongest to weakest,
+        # if both sides have a type in common - compare it and return result
+        for kind in reversed(self._fields):  # pylint: disable=no-member
+            self_digest = getattr(self, kind)
+            other_digest = getattr(other, kind)
+            if self_digest is not None and other_digest is not None:
+                return self_digest == other_digest
+        # If no common digest type found, we can't compare, raise an error
+        raise ValueError(f"No common digest type for {self} and {other}")
+
+    def __ne__(self, other):
+        return not self == other
+
+    def update_source(self, source: t.Dict):
+        # Find digest types that are both not null in self and set in the source
+        to_update = {
+            kind: digest
+            for kind, digest in self._asdict().items()  # pylint: disable=no-member
+            if kind in source and digest is not None
+        }
+        if not to_update:
+            # We don't have a common digest type with the source, bail out
+            raise SourceUpdateError(f"No matching digest type for {self} in {source}")
+        log.debug("Updating %s in %s", to_update.keys(), source)
+        source.update(to_update)
+
+
+class MultiHash:
+    __slots__ = ("md5", "sha1", "sha256", "sha512")
+
+    def __init__(self, *args, **kwargs):
+        self.md5 = hashlib.md5(*args, **kwargs)  # nosec
+        self.sha1 = hashlib.sha1(*args, **kwargs)  # nosec
+        self.sha256 = hashlib.sha256(*args, **kwargs)
+        self.sha512 = hashlib.sha512(*args, **kwargs)
+
+    def update(self, data):
+        self.md5.update(data)
+        self.sha1.update(data)
+        self.sha256.update(data)
+        self.sha512.update(data)
+
+    def hexdigest(self):
+        return MultiDigest(
+            md5=self.md5.hexdigest(),
+            sha1=self.sha1.hexdigest(),
+            sha256=self.sha256.hexdigest(),
+            sha512=self.sha512.hexdigest(),
+        )

--- a/src/lib/errors.py
+++ b/src/lib/errors.py
@@ -34,6 +34,10 @@ class SourceUnsupported(SourceLoadError):
     """Don't know how to handle flatpak-builder source item"""
 
 
+class SourceUpdateError(ManifestUpdateError):
+    """Error updating flatpak-builder source"""
+
+
 class AppdataError(ManifestError):
     """Error processing metainfo.xml"""
 

--- a/src/lib/utils.py
+++ b/src/lib/utils.py
@@ -19,7 +19,6 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 import datetime as dt
-import hashlib
 import json
 import logging
 import os
@@ -43,6 +42,7 @@ import editorconfig
 
 from . import externaldata, TIMEOUT_CONNECT, HTTP_CHUNK_SIZE, OPERATORS
 from .errors import CheckerRemoteError, CheckerQueryError, CheckerFetchError
+from .checksums import MultiHash
 
 import gi
 
@@ -122,7 +122,7 @@ async def get_extra_data_info_from_url(
                 f"Wrong content type '{content_type}' received from '{url}'"
             )
 
-        checksum = hashlib.sha256()
+        checksum = MultiHash()
         size = 0
         async for chunk in response.content.iter_chunked(HTTP_CHUNK_SIZE):
             checksum.update(chunk)

--- a/src/main.py
+++ b/src/main.py
@@ -67,6 +67,7 @@ def print_outdated_external_data(manifest_checker: checker.ManifestChecker):
             if data.state == ExternalData.State.BROKEN
             else "CHANGE SOON"
         )
+        checksums = {}
         if data.new_version:
             if data.type == ExternalData.Type.GIT:
                 message_tmpl = (
@@ -80,15 +81,20 @@ def print_outdated_external_data(manifest_checker: checker.ManifestChecker):
                     "  Timestamp: {timestamp}\n"
                 )
             else:
+                assert isinstance(data, ExternalData)
                 message_tmpl = (
                     "{data_state}: {data_name}\n"
                     " Has a new version:\n"
                     "  URL:       {url}\n"
-                    "  SHA256:    {checksum}\n"
+                    "  MD5:       {md5}\n"
+                    "  SHA1:      {sha1}\n"
+                    "  SHA256:    {sha256}\n"
+                    "  SHA512:    {sha512}\n"
                     "  Size:      {size}\n"
                     "  Version:   {version}\n"
                     "  Timestamp: {timestamp}\n"
                 )
+                checksums = data.new_version.checksum._asdict()
         elif data.state == ExternalData.State.BROKEN:
             message_tmpl = (
                 # fmt: off
@@ -100,7 +106,7 @@ def print_outdated_external_data(manifest_checker: checker.ManifestChecker):
         message = message_tmpl.format(
             data_state=state_txt,
             data_name=data.filename,
-            **(data.new_version or data.current_version)._asdict(),
+            **{**(data.new_version or data.current_version)._asdict(), **checksums},
         )
         print(message, flush=True)
     return len(ext_data)

--- a/tests/test_anityachecker.py
+++ b/tests/test_anityachecker.py
@@ -4,6 +4,7 @@ from distutils.version import LooseVersion
 
 from src.checker import ManifestChecker
 from src.lib.externaldata import ExternalFile, ExternalGitRef
+from src.lib.checksums import MultiDigest
 from src.lib.utils import init_logging
 
 TEST_MANIFEST = os.path.join(os.path.dirname(__file__), "org.flatpak.Flatpak.yml")
@@ -33,10 +34,12 @@ class TestAnityaChecker(unittest.IsolatedAsyncioTestCase):
                 self.assertIsInstance(data.new_version.size, int)
                 self.assertGreater(data.new_version.size, 0)
                 self.assertIsNotNone(data.new_version.checksum)
-                self.assertIsInstance(data.new_version.checksum, str)
+                self.assertIsInstance(data.new_version.checksum, MultiDigest)
                 self.assertNotEqual(
                     data.new_version.checksum,
-                    "90ed475f37584f646e9ef829932b2525d5c6fc2e0147e8d611bc50aa0e718598",
+                    MultiDigest(
+                        sha256="90ed475f37584f646e9ef829932b2525d5c6fc2e0147e8d611bc50aa0e718598"
+                    ),
                 )
             elif data.filename == "boost_1_74_0.tar.bz2":
                 self.assertIsNotNone(data.new_version)
@@ -52,10 +55,12 @@ class TestAnityaChecker(unittest.IsolatedAsyncioTestCase):
                 self.assertIsInstance(data.new_version.size, int)
                 self.assertGreater(data.new_version.size, 0)
                 self.assertIsNotNone(data.new_version.checksum)
-                self.assertIsInstance(data.new_version.checksum, str)
+                self.assertIsInstance(data.new_version.checksum, MultiDigest)
                 self.assertNotEqual(
                     data.new_version.checksum,
-                    "83bfc1507731a0906e387fc28b7ef5417d591429e51e788417fe9ff025e116b1",
+                    MultiDigest(
+                        sha256="83bfc1507731a0906e387fc28b7ef5417d591429e51e788417fe9ff025e116b1"
+                    ),
                 )
             elif data.filename == "flatpak-1.8.2.tar.xz":
                 self.assertIsNotNone(data.new_version)
@@ -71,10 +76,12 @@ class TestAnityaChecker(unittest.IsolatedAsyncioTestCase):
                 self.assertIsInstance(data.new_version.size, int)
                 self.assertGreater(data.new_version.size, 0)
                 self.assertIsNotNone(data.new_version.checksum)
-                self.assertIsInstance(data.new_version.checksum, str)
+                self.assertIsInstance(data.new_version.checksum, MultiDigest)
                 self.assertNotEqual(
                     data.new_version.checksum,
-                    "7926625df7c2282a5ee1a8b3c317af53d40a663b1bc6b18a2dc8747e265085b0",
+                    MultiDigest(
+                        sha256="7926625df7c2282a5ee1a8b3c317af53d40a663b1bc6b18a2dc8747e265085b0"
+                    ),
                 )
             elif data.filename == "ostree.git":
                 self.assertIsNotNone(data.new_version)

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -28,6 +28,7 @@ from xml.dom import minidom
 
 from src.lib.utils import init_logging
 from src.lib.externaldata import ExternalData, Checker
+from src.lib.checksums import MultiDigest
 from src.checker import ManifestChecker
 
 TEST_MANIFEST = os.path.join(
@@ -72,7 +73,7 @@ class UpdateEverythingChecker(DummyChecker):
         external_data.state = ExternalData.State.BROKEN
         external_data.new_version = external_data.current_version._replace(
             size=self.SIZE,
-            checksum=self.CHECKSUM,
+            checksum=MultiDigest(sha256=self.CHECKSUM),
             version=self.VERSION,
             timestamp=self.TIMESTAMP,
         )
@@ -411,6 +412,9 @@ size: {UpdateEverythingChecker.SIZE}
 
         for data in ext_data:
             if data.new_version:
+                self.assertIsInstance(data.new_version.url, str)
+                self.assertIsInstance(data.new_version.checksum, MultiDigest)
+                self.assertIsInstance(data.new_version.size, int)
                 ext_data_with_new_version += 1
 
         self.assertEqual(ext_data_with_new_version, NUM_NEW_VERSIONS)
@@ -440,7 +444,9 @@ size: {UpdateEverythingChecker.SIZE}
         )
         self.assertEqual(
             relative_redirect.new_version.checksum,
-            "e4d67702da4eeeb2f15629b65bf6767c028a511839c14ed44d9f34479eaa2b94",
+            MultiDigest(
+                sha256="e4d67702da4eeeb2f15629b65bf6767c028a511839c14ed44d9f34479eaa2b94"
+            ),
         )
         self.assertEqual(relative_redirect.new_version.size, 18)
 

--- a/tests/test_chromiumchecker.py
+++ b/tests/test_chromiumchecker.py
@@ -10,6 +10,7 @@ from src.lib.externaldata import (
     ExternalGitRef,
     ExternalGitRepo,
 )
+from src.lib.checksums import MultiDigest
 from src.lib.utils import init_logging
 
 TEST_MANIFEST = os.path.join(os.path.dirname(__file__), "org.chromium.Chromium.yaml")
@@ -34,7 +35,7 @@ class TestChromiumChecker(unittest.IsolatedAsyncioTestCase):
             if isinstance(data, ExternalData):
                 self.assertIsInstance(data.new_version, ExternalFile)
                 self.assertIsNotNone(data.new_version.checksum)
-                self.assertIsInstance(data.new_version.checksum, str)
+                self.assertIsInstance(data.new_version.checksum, MultiDigest)
                 if data.filename.startswith("chromium-"):
                     self.assertRegex(
                         data.new_version.url,
@@ -42,7 +43,9 @@ class TestChromiumChecker(unittest.IsolatedAsyncioTestCase):
                     )
                     self.assertNotEqual(
                         data.new_version.checksum,
-                        "abe11d0cb1ff21278aad2eec1a1e279d59176b15331804d7df1807446786d59e",
+                        MultiDigest(
+                            sha256="abe11d0cb1ff21278aad2eec1a1e279d59176b15331804d7df1807446786d59e"
+                        ),
                     )
                 elif data.filename.startswith("clang-"):
                     self.assertRegex(
@@ -51,7 +54,9 @@ class TestChromiumChecker(unittest.IsolatedAsyncioTestCase):
                     )
                     self.assertNotEqual(
                         data.new_version.checksum,
-                        "676448e180fb060d3983f24476a2136eac83c6011c600117686035634a2bbe26",
+                        MultiDigest(
+                            sha256="676448e180fb060d3983f24476a2136eac83c6011c600117686035634a2bbe26"
+                        ),
                     )
                 else:
                     self.fail(f"unexpected extra-data filename {data.filename}")

--- a/tests/test_debianrepochecker.py
+++ b/tests/test_debianrepochecker.py
@@ -4,6 +4,7 @@ import datetime
 
 from src.checker import ManifestChecker
 from src.lib.utils import init_logging
+from src.lib.checksums import MultiDigest
 
 TEST_MANIFEST = os.path.join(
     os.path.dirname(__file__), "org.debian.tracker.pkg.apt.yml"
@@ -26,7 +27,7 @@ class TestDebianRepoChecker(unittest.IsolatedAsyncioTestCase):
             self.assertIsNotNone(data.new_version.timestamp)
             self.assertIsInstance(data.new_version.timestamp, datetime.date)
             self.assertNotEqual(data.new_version.url, data.current_version.url)
-            self.assertIsInstance(data.new_version.checksum, str)
+            self.assertIsInstance(data.new_version.checksum, MultiDigest)
             self.assertNotEqual(
                 data.new_version.checksum, data.current_version.checksum
             )

--- a/tests/test_gnomechecker.py
+++ b/tests/test_gnomechecker.py
@@ -24,6 +24,7 @@ from distutils.version import LooseVersion
 
 from src.lib.utils import init_logging
 from src.checker import ManifestChecker
+from src.lib.checksums import MultiDigest
 
 TEST_MANIFEST = os.path.join(os.path.dirname(__file__), "org.gnome.baobab.json")
 
@@ -39,10 +40,12 @@ class TestGNOMEChecker(unittest.IsolatedAsyncioTestCase):
         for data in ext_data:
             self.assertIsNotNone(data.new_version)
             self.assertIsNotNone(data.new_version.checksum)
-            self.assertIsInstance(data.new_version.checksum, str)
+            self.assertIsInstance(data.new_version.checksum, MultiDigest)
             self.assertNotEqual(
                 data.new_version.checksum,
-                "0000000000000000000000000000000000000000000000000000000000000000",
+                MultiDigest(
+                    sha256="0000000000000000000000000000000000000000000000000000000000000000"
+                ),
             )
             self.assertIsNotNone(data.new_version.version)
             self.assertIsInstance(data.new_version.version, str)

--- a/tests/test_htmlchecker.py
+++ b/tests/test_htmlchecker.py
@@ -26,6 +26,7 @@ from distutils.version import LooseVersion
 
 from src.lib.utils import init_logging
 from src.checker import ManifestChecker
+from src.lib.checksums import MultiDigest
 
 TEST_MANIFEST = os.path.join(os.path.dirname(__file__), "org.x.xeyes.yml")
 
@@ -68,10 +69,12 @@ class TestHTMLChecker(unittest.IsolatedAsyncioTestCase):
         self.assertIsInstance(data.new_version.size, int)
         self.assertGreater(data.new_version.size, 0)
         self.assertIsNotNone(data.new_version.checksum)
-        self.assertIsInstance(data.new_version.checksum, str)
+        self.assertIsInstance(data.new_version.checksum, MultiDigest)
         self.assertNotEqual(
             data.new_version.checksum,
-            "0000000000000000000000000000000000000000000000000000000000000000",
+            MultiDigest(
+                sha256="0000000000000000000000000000000000000000000000000000000000000000"
+            ),
         )
 
     def _test_check_with_url_template(self, data):
@@ -85,10 +88,12 @@ class TestHTMLChecker(unittest.IsolatedAsyncioTestCase):
         self.assertIsInstance(data.new_version.size, int)
         self.assertGreater(data.new_version.size, 0)
         self.assertIsNotNone(data.new_version.checksum)
-        self.assertIsInstance(data.new_version.checksum, str)
+        self.assertIsInstance(data.new_version.checksum, MultiDigest)
         self.assertEqual(
             data.new_version.checksum,
-            "d73b62f29eb98d850f16b76d759395180b860b613fbe1686b18eee99a6e3773f",
+            MultiDigest(
+                sha256="d73b62f29eb98d850f16b76d759395180b860b613fbe1686b18eee99a6e3773f"
+            ),
         )
 
     def _test_combo_pattern(self, data):
@@ -104,7 +109,9 @@ class TestHTMLChecker(unittest.IsolatedAsyncioTestCase):
         )
         self.assertNotEqual(
             data.new_version.checksum,
-            "0000000000000000000000000000000000000000000000000000000000000000",
+            MultiDigest(
+                sha256="0000000000000000000000000000000000000000000000000000000000000000"
+            ),
         )
 
     def _test_combo_pattern_nosort(self, data):
@@ -120,7 +127,9 @@ class TestHTMLChecker(unittest.IsolatedAsyncioTestCase):
         )
         self.assertNotEqual(
             data.new_version.checksum,
-            "0000000000000000000000000000000000000000000000000000000000000000",
+            MultiDigest(
+                sha256="0000000000000000000000000000000000000000000000000000000000000000"
+            ),
         )
 
     def _test_no_match(self, data):

--- a/tests/test_jetbrainschecker.py
+++ b/tests/test_jetbrainschecker.py
@@ -3,6 +3,7 @@ import unittest
 
 from src.checker import ManifestChecker
 from src.lib.utils import init_logging
+from src.lib.checksums import MultiDigest
 
 TEST_MANIFEST = os.path.join(os.path.dirname(__file__), "com.jetbrains.PhpStorm.json")
 
@@ -26,10 +27,12 @@ class TestJetBrainsChecker(unittest.IsolatedAsyncioTestCase):
         self.assertIsInstance(data.new_version.size, int)
         self.assertGreater(data.new_version.size, 0)
         self.assertIsNotNone(data.new_version.checksum)
-        self.assertIsInstance(data.new_version.checksum, str)
+        self.assertIsInstance(data.new_version.checksum, MultiDigest)
         self.assertNotEqual(
             data.new_version.checksum,
-            "0000000000000000000000000000000000000000000000000000000000000000",
+            MultiDigest(
+                sha256="0000000000000000000000000000000000000000000000000000000000000000"
+            ),
         )
 
     def _find_by_filename(self, ext_data, filename):

--- a/tests/test_jsonchecker.py
+++ b/tests/test_jsonchecker.py
@@ -5,6 +5,7 @@ import datetime
 from src.checker import ManifestChecker
 from src.lib.utils import init_logging
 from src.lib.externaldata import ExternalFile, ExternalGitRef
+from src.lib.checksums import MultiDigest
 
 TEST_MANIFEST = os.path.join(os.path.dirname(__file__), "io.github.stedolan.jq.yml")
 
@@ -30,10 +31,12 @@ class TestJSONChecker(unittest.IsolatedAsyncioTestCase):
                 self.assertIsInstance(data.new_version.size, int)
                 self.assertGreater(data.new_version.size, 0)
                 self.assertIsNotNone(data.new_version.checksum)
-                self.assertIsInstance(data.new_version.checksum, str)
+                self.assertIsInstance(data.new_version.checksum, MultiDigest)
                 self.assertNotEqual(
                     data.new_version.checksum,
-                    "0000000000000000000000000000000000000000000000000000000000000000",
+                    MultiDigest(
+                        sha256="0000000000000000000000000000000000000000000000000000000000000000"
+                    ),
                 )
             elif data.filename == "oniguruma.git":
                 self.assertIsInstance(data.new_version, ExternalGitRef)

--- a/tests/test_pypichecker.py
+++ b/tests/test_pypichecker.py
@@ -3,6 +3,7 @@ import unittest
 
 from src.checker import ManifestChecker
 from src.lib.utils import init_logging
+from src.lib.checksums import MultiDigest
 
 TEST_MANIFEST = os.path.join(os.path.dirname(__file__), "com.valvesoftware.Steam.yml")
 
@@ -23,7 +24,7 @@ class TestPyPIChecker(unittest.IsolatedAsyncioTestCase):
                 self.assertIsNotNone(data.new_version.checksum)
                 self.assertIsNotNone(data.new_version.version)
                 self.assertNotEqual(data.new_version.url, data.current_version.url)
-                self.assertIsInstance(data.new_version.checksum, str)
+                self.assertIsInstance(data.new_version.checksum, MultiDigest)
                 self.assertNotEqual(
                     data.new_version.checksum, data.current_version.checksum
                 )

--- a/tests/test_rpmrepochecker.py
+++ b/tests/test_rpmrepochecker.py
@@ -3,6 +3,7 @@ import os
 
 from src.checker import ManifestChecker
 from src.lib.utils import init_logging
+from src.lib.checksums import MultiDigest
 
 TEST_MANIFEST = os.path.join(os.path.dirname(__file__), "com.visualstudio.code.yaml")
 
@@ -21,7 +22,7 @@ class TestRPMRepoChecker(unittest.IsolatedAsyncioTestCase):
             self.assertIsNotNone(data.new_version.checksum)
             self.assertIsNotNone(data.new_version.version)
             self.assertNotEqual(data.new_version.url, data.current_version.url)
-            self.assertIsInstance(data.new_version.checksum, str)
+            self.assertIsInstance(data.new_version.checksum, MultiDigest)
             self.assertNotEqual(
                 data.new_version.checksum, data.current_version.checksum
             )

--- a/tests/test_rustchecker.py
+++ b/tests/test_rustchecker.py
@@ -3,6 +3,7 @@ import unittest
 
 from src.checker import ManifestChecker
 from src.lib.utils import init_logging
+from src.lib.checksums import MultiDigest
 
 TEST_MANIFEST = os.path.join(
     os.path.dirname(__file__), "org.freedesktop.Sdk.Extension.rust-nightly.yml"
@@ -26,10 +27,12 @@ class TestRustChecker(unittest.IsolatedAsyncioTestCase):
         )
         self.assertIsNone(data.new_version.size)
         self.assertIsNotNone(data.new_version.checksum)
-        self.assertIsInstance(data.new_version.checksum, str)
+        self.assertIsInstance(data.new_version.checksum, MultiDigest)
         self.assertNotEqual(
             data.new_version.checksum,
-            "24b4681187654778817652273a68a4d55f5090604cd14b1f1c3ff8785ad24b99",
+            MultiDigest(
+                sha256="24b4681187654778817652273a68a4d55f5090604cd14b1f1c3ff8785ad24b99"
+            ),
         )
 
 

--- a/tests/test_snapcraftchecker.py
+++ b/tests/test_snapcraftchecker.py
@@ -3,6 +3,7 @@ import unittest
 
 from src.checker import ManifestChecker
 from src.lib.utils import init_logging
+from src.lib.checksums import MultiDigest
 
 TEST_MANIFEST = os.path.join(os.path.dirname(__file__), "com.nordpass.NordPass.yaml")
 
@@ -26,10 +27,12 @@ class TestSnapctaftChecker(unittest.IsolatedAsyncioTestCase):
         self.assertIsInstance(data.new_version.size, int)
         self.assertGreater(data.new_version.size, 0)
         self.assertIsNotNone(data.new_version.checksum)
-        self.assertIsInstance(data.new_version.checksum, str)
+        self.assertIsInstance(data.new_version.checksum, MultiDigest)
         self.assertNotEqual(
             data.new_version.checksum,
-            "0000000000000000000000000000000000000000000000000000000000000000",
+            MultiDigest(
+                sha256="0000000000000000000000000000000000000000000000000000000000000000"
+            ),
         )
 
     def _find_by_filename(self, ext_data, filename):

--- a/tests/test_urlchecker.py
+++ b/tests/test_urlchecker.py
@@ -3,6 +3,7 @@ import os
 
 from src.checker import ManifestChecker
 from src.lib.utils import init_logging
+from src.lib.checksums import MultiDigest
 
 TEST_MANIFEST = os.path.join(os.path.dirname(__file__), "com.unity.UnityHub.yaml")
 
@@ -22,10 +23,12 @@ class TestURLChecker(unittest.IsolatedAsyncioTestCase):
         self.assertIsInstance(data.new_version.size, int)
         self.assertGreater(data.new_version.size, 0)
         self.assertIsNotNone(data.new_version.checksum)
-        self.assertIsInstance(data.new_version.checksum, str)
+        self.assertIsInstance(data.new_version.checksum, MultiDigest)
         self.assertNotEqual(
             data.new_version.checksum,
-            "0000000000000000000000000000000000000000000000000000000000000000",
+            MultiDigest(
+                sha256="0000000000000000000000000000000000000000000000000000000000000000"
+            ),
         )
         self.assertIsNotNone(data.new_version.version)
 


### PR DESCRIPTION
This is rather big change-set for a seemingly small feature. Given that different checkers can get different digests, while sources may set different digests and expect them to be updated, we need some layer of abstraction between checkers and flatpak-builder sources. Thus, internal representation of checksum changed from plain sha256 digests to a special `MultiDigest` container.

While retrieving remote checksums is straightforward, applying updates to sources isn't. There are some corner cases, e.g.

- What should we do if the checker got `md5` and `sha256`, but the source has set only `sha512`?