### PR TITLE
Use common code for running commands

### DIFF
--- a/src/lib/utils.py
+++ b/src/lib/utils.py
@@ -197,14 +197,11 @@ def run_command(argv, cwd=None, env=None, bwrap=True, bwrap_args=None):
 
 def check_bwrap():
     try:
-        p = run_command(["/bin/true"])
-        if p.returncode == 0:
-            return True
-    except FileNotFoundError:
-        pass
-
-    logging.warning("bwrap is not available")
-    return False
+        subprocess.run(wrap_in_bwrap(["/bin/true"]), check=True)
+    except (FileNotFoundError, subprocess.CalledProcessError) as err:
+        log.debug("bwrap unavailable: %s", err)
+        return False
+    return True
 
 
 async def git_ls_remote(url: str) -> t.Dict[str, str]:

--- a/src/lib/utils.py
+++ b/src/lib/utils.py
@@ -302,27 +302,16 @@ class Command:
 
 
 async def git_ls_remote(url: str) -> t.Dict[str, str]:
-    git_cmd = ["git", "ls-remote", "--exit-code", url]
-    if check_bwrap():
-        git_cmd = wrap_in_bwrap(
-            git_cmd,
-            bwrap_args=[
-                # fmt: off
-                "--share-net",
-                "--dev", "/dev",
-                "--ro-bind", "/etc/ssl", "/etc/ssl",
-                "--ro-bind-try", "/etc/pki", "/etc/pki",
-                "--ro-bind", "/etc/resolv.conf", "/etc/resolv.conf",
-                # fmt: on
-            ],
-        )
-    git_proc = await asyncio.create_subprocess_exec(
-        *git_cmd,
-        stdout=asyncio.subprocess.PIPE,
-        env=clear_env(os.environ),
+    git_cmd = Command(
+        ["git", "ls-remote", "--exit-code", url],
+        allow_network=True,
+        allow_paths=[
+            Command.SandboxPath("/etc/ssl", True, True),
+            Command.SandboxPath("/etc/pki", True, True),
+            Command.SandboxPath("/etc/resolv.conf", True, False),
+        ],
     )
-    git_stdout_raw, _ = await git_proc.communicate()
-    assert git_proc.returncode == 0
+    git_stdout_raw, _ = await git_cmd.run()
     git_stdout = git_stdout_raw.decode()
 
     return {r: c for c, r in (l.split() for l in git_stdout.splitlines())}


### PR DESCRIPTION
Sharing code responsible for running subprocesses saves us several repeated patterns.