### PR TITLE
Handle non-fatal errors as custom exceptions

### DIFF
--- a/src/checkers/pypichecker.py
+++ b/src/checkers/pypichecker.py
@@ -6,6 +6,7 @@ import typing as t
 from ..lib import OPERATORS_SCHEMA
 from ..lib.externaldata import Checker, ExternalFile
 from ..lib.utils import filter_versions
+from ..lib.errors import CheckerQueryError
 
 log = logging.getLogger(__name__)
 
@@ -63,9 +64,10 @@ class PyPIChecker(Checker):
 
         try:
             pypi_version, pypi_download, pypi_date = downloads[-1]
-        except IndexError:
-            log.error("Couldn't find %s for package %s", package_type, package_name)
-            return
+        except IndexError as err:
+            raise CheckerQueryError(
+                f"Couldn't find {package_type} for package {package_name}"
+            ) from err
 
         new_version = ExternalFile(
             url=pypi_download["url"],

--- a/src/lib/errors.py
+++ b/src/lib/errors.py
@@ -1,0 +1,34 @@
+import typing as t
+
+
+class FlatpakExternalDataCheckerError(Exception):
+    """Base class for errors in the proram"""
+
+
+class CheckerError(FlatpakExternalDataCheckerError):
+    """Error checking a flatpak-builder source"""
+
+    def __init__(self, message: t.Optional[str] = None):
+        super().__init__(message)
+        self.message = message or self.__doc__
+
+    def __str__(self):
+        if self.__cause__ is not None:
+            return f"{self.message}: {self.__cause__}"
+        return self.message
+
+
+class CheckerMetadataError(CheckerError):
+    """Error processing checker metadata"""
+
+
+class CheckerRemoteError(CheckerError):
+    """Error processing remote data"""
+
+
+class CheckerQueryError(CheckerRemoteError):
+    """Error querying for new versions"""
+
+
+class CheckerFetchError(CheckerRemoteError):
+    """Error downloading upstream source"""


### PR DESCRIPTION
Adds a set of custom exceptions that are raised from checkers and catched on manifest check.

Closes #212, fixes #122, supersedes #130, helps #201