### PR TITLE
Use a shared per-manifest HTTP client session

### DIFF
--- a/src/checker.py
+++ b/src/checker.py
@@ -203,7 +203,7 @@ class ManifestChecker:
     ):
         src_rel_path = os.path.relpath(data.source_path, self._root_manifest_dir)
         counter.started += 1
-        checkers = [i for i in (c() for c in self._checkers) if i.should_check(data)]
+        checkers = [c() for c in self._checkers if c.should_check(data)]
         if not checkers:
             counter.finished += 1
             log.info(

--- a/src/checkers/gitchecker.py
+++ b/src/checkers/gitchecker.py
@@ -69,7 +69,8 @@ class GitChecker(Checker):
     }
     SUPPORTED_DATA_CLASSES = [ExternalGitRepo]
 
-    def should_check(self, external_data: t.Union[ExternalData, ExternalGitRepo]):
+    @classmethod
+    def should_check(cls, external_data: t.Union[ExternalData, ExternalGitRepo]):
         return isinstance(external_data, ExternalGitRepo)
 
     async def validate_checker_data(

--- a/src/checkers/urlchecker.py
+++ b/src/checkers/urlchecker.py
@@ -72,9 +72,10 @@ class URLChecker(Checker):
         "required": ["url"],
     }
 
-    def should_check(self, external_data: t.Union[ExternalData, ExternalGitRepo]):
+    @classmethod
+    def should_check(cls, external_data: t.Union[ExternalData, ExternalGitRepo]):
         return isinstance(external_data, ExternalData) and (
-            external_data.checker_data.get("type") == self.CHECKER_DATA_TYPE
+            external_data.checker_data.get("type") == cls.CHECKER_DATA_TYPE
             or external_data.type == external_data.Type.EXTRA_DATA
         )
 

--- a/src/lib/externaldata.py
+++ b/src/lib/externaldata.py
@@ -384,15 +384,16 @@ class Checker:
             "If schema is not declared, this method must be overridden"
         )
 
+    @classmethod
     def should_check(
-        self, external_data: t.Union[ExternalData, ExternalGitRepo]
+        cls, external_data: t.Union[ExternalData, ExternalGitRepo]
     ) -> bool:
         supported = any(
-            isinstance(external_data, c) for c in self.SUPPORTED_DATA_CLASSES
+            isinstance(external_data, c) for c in cls.SUPPORTED_DATA_CLASSES
         )
         applicable = (
-            self.CHECKER_DATA_TYPE is not None
-            and external_data.checker_data.get("type") == self.CHECKER_DATA_TYPE
+            cls.CHECKER_DATA_TYPE is not None
+            and external_data.checker_data.get("type") == cls.CHECKER_DATA_TYPE
         )
         return applicable and supported
 

--- a/src/lib/externaldata.py
+++ b/src/lib/externaldata.py
@@ -409,4 +409,4 @@ class Checker:
             raise CheckerMetadataError("Invalid metadata schema") from err
 
     async def check(self, external_data: t.Union[ExternalData, ExternalGitRepo]):
-        pass
+        raise NotImplementedError

--- a/src/lib/externaldata.py
+++ b/src/lib/externaldata.py
@@ -358,22 +358,8 @@ class Checker:
     SUPPORTED_DATA_CLASSES: t.List[t.Type[ExternalBase]] = [ExternalData]
     session: aiohttp.ClientSession
 
-    def __init__(self):
-        self.session = None
-
-    async def __aenter__(self):
-        log.debug("Starting HTTP session for %s", self)
-        self.session = aiohttp.ClientSession(
-            raise_for_status=True,
-            headers=HTTP_CLIENT_HEADERS,
-            timeout=aiohttp.ClientTimeout(connect=TIMEOUT_CONNECT, total=TIMEOUT_TOTAL),
-        )
-        await self.session.__aenter__()
-        return self
-
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
-        log.debug("Closing HTTP session for %s", self)
-        await self.session.__aexit__(exc_type, exc_val, exc_tb)
+    def __init__(self, session: aiohttp.ClientSession):
+        self.session = session
 
     def get_json_schema(  # pylint: disable=unused-argument
         self, external_data: t.Union[ExternalData, ExternalGitRepo]

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -50,7 +50,8 @@ class DummyChecker(Checker):
     def get_json_schema(self, external_data):
         return None
 
-    def should_check(self, external_data):
+    @classmethod
+    def should_check(cls, external_data):
         return True
 
     async def check(self, external_data):


### PR DESCRIPTION
This will allow us set up connection limits, and potentially speeds up checking multiples sources by reusing more connections.