### PR TITLE
Collect errors and set non-zero exit code if any occured

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -39,6 +39,6 @@ class TestEntrypoint(unittest.IsolatedAsyncioTestCase):
 
     async def test_full_run(self):
         args1 = main.parse_cli_args(["--update", "--commit-only", self.manifest_path])
-        self.assertEqual(await main.run_with_args(args1), (2, True))
+        self.assertEqual(await main.run_with_args(args1), (2, 0, True))
         args2 = main.parse_cli_args([self.manifest_path])
-        self.assertEqual(await main.run_with_args(args2), (0, False))
+        self.assertEqual(await main.run_with_args(args2), (0, 0, False))


### PR DESCRIPTION
Collect all the non-fatal errors occurred during check, and if a special option is given, set the exit status based on amount of errors collected.
Fixes #201