### PR TITLE
Check content type of downloaded files

### DIFF
--- a/src/checkers/htmlchecker.py
+++ b/src/checkers/htmlchecker.py
@@ -162,8 +162,8 @@ class HTMLChecker(Checker):
             )
         except NETWORK_ERRORS as err:
             raise CheckerFetchError from err
-        else:
-            new_version = new_version._replace(  # pylint: disable=no-member
-                version=latest_version
-            )
-            external_data.set_new_version(new_version)
+
+        new_version = new_version._replace(
+            version=latest_version  # pylint: disable=no-member
+        )
+        external_data.set_new_version(new_version)

--- a/src/checkers/htmlchecker.py
+++ b/src/checkers/htmlchecker.py
@@ -25,7 +25,12 @@ from string import Template
 from distutils.version import LooseVersion
 import typing as t
 
-from ..lib import utils, NETWORK_ERRORS
+from ..lib import (
+    utils,
+    NETWORK_ERRORS,
+    WRONG_CONTENT_TYPES_FILE,
+    WRONG_CONTENT_TYPES_ARCHIVE,
+)
 from ..lib.externaldata import ExternalData, Checker
 from ..lib.errors import CheckerMetadataError, CheckerQueryError, CheckerFetchError
 
@@ -156,9 +161,17 @@ class HTMLChecker(Checker):
         assert latest_version is not None
         assert latest_url is not None
 
+        if external_data.type == ExternalData.Type.ARCHIVE:
+            wrong_content_types = WRONG_CONTENT_TYPES_ARCHIVE
+        else:
+            wrong_content_types = WRONG_CONTENT_TYPES_FILE
+
         try:
             new_version = await utils.get_extra_data_info_from_url(
-                latest_url, follow_redirects=follow_redirects, session=self.session
+                url=latest_url,
+                follow_redirects=follow_redirects,
+                session=self.session,
+                content_type_deny=wrong_content_types,
             )
         except NETWORK_ERRORS as err:
             raise CheckerFetchError from err

--- a/src/lib/__init__.py
+++ b/src/lib/__init__.py
@@ -1,3 +1,4 @@
+import re
 import operator
 
 import aiohttp
@@ -22,6 +23,14 @@ NETWORK_ERRORS = (
     aiohttp.ServerDisconnectedError,
     aiohttp.ServerTimeoutError,
 )
+
+WRONG_CONTENT_TYPES_FILE = [
+    re.compile(r"^text/html$"),
+    re.compile(r"^application/xhtml(\+.+)?$"),
+]
+WRONG_CONTENT_TYPES_ARCHIVE = [
+    re.compile(r"^text/.*$"),
+] + WRONG_CONTENT_TYPES_FILE
 
 OPERATORS = {
     "<": operator.lt,


### PR DESCRIPTION
Add a list of known-wrong `Content-Type` header patterns, and reject downloaded file if its `Content-Type` matches. The idea is to catch error pages returned by services without HTTP error status code, and avoid submitting them as "updates".
Should fix #168, assuming that the infamous SourceForge page has C-T alike `text/html`.

Ideally, we should add C-T denylist for URLChecker, too, but just throwing it in will break our tests (httbin[go] returns `text/html` for its `/base64/` URL). Given that it's most primarily targeted at SourceForge, and sources from there are unlikely to be `extra-data`, I consider the denylist for URLChecker not as important.