### PR TITLE
Split "collect data from source" logic to a separate method

### DIFF
--- a/src/checker.py
+++ b/src/checker.py
@@ -45,8 +45,6 @@ import logging
 import os
 from xml.sax import SAXParseException
 
-from gi.repository import GLib
-
 
 MAIN_SRC_PROP = "is-main-source"
 MAX_MANIFEST_SIZE = 1024 * 100

--- a/src/checker.py
+++ b/src/checker.py
@@ -126,6 +126,8 @@ class ManifestChecker:
         self._collect_external_data()
 
     def _read_manifest(self, manifest_path: str) -> t.Union[t.List, t.Dict]:
+        if manifest_path in self._manifest_contents:
+            return self._manifest_contents[manifest_path]
         contents = read_manifest(manifest_path)
         self._manifest_contents[manifest_path] = contents
         return contents

--- a/src/lib/externaldata.py
+++ b/src/lib/externaldata.py
@@ -82,21 +82,6 @@ class ExternalBase(abc.ABC):
         return data_cls.from_source_impl(source_path, source)
 
     @classmethod
-    def from_sources(
-        cls, source_path: str, sources: t.List[t.Dict]
-    ) -> t.List[ExternalBase]:
-        external_data = []
-
-        for source in sources:
-            assert isinstance(source, dict), source
-
-            data = cls.from_source(source_path, source)
-            if data:
-                external_data.append(data)
-
-        return external_data
-
-    @classmethod
     def from_source_impl(cls, source_path: str, source: t.Dict) -> ExternalBase:
         raise NotImplementedError
 

--- a/tests/org.externaldatachecker.Manifest.json
+++ b/tests/org.externaldatachecker.Manifest.json
@@ -96,6 +96,13 @@
                 "phony-external-source-single-item.json",
                 "phony-too-large-generated-sources.json"
             ]
+        },
+        {
+            "name": "same-source-ref",
+            "sources": [
+                /* Make sure we don't collect the same source multiple times */
+                "phony-external-source.json"
+            ]
         }
     ]
 }

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -208,7 +208,8 @@ modules:
   - name: foo
     # Anchor
     sources: &foo-sources
-      - type: extra-data                  # Cool comments
+      - &foo-i386
+        type: extra-data                  # Cool comments
         filename: UnityHubSetup.AppImage  # Very nice
         url: https://public-cdn.cloud.unity3d.com/hub/prod/UnityHubSetup.AppImage
         sha256: c521e2caf2ce8c8302cc9d8f385648c7d8c76ae29ac24ec0c0ffd3cd67a915fc
@@ -223,6 +224,8 @@ modules:
         size: 63236599
         only-arches:
           - x86_64
+
+      - *foo-i386
 
   - name: foo-32bit
     # Alias
@@ -236,7 +239,8 @@ modules:
   - name: foo
     # Anchor
     sources: &foo-sources
-      - type: extra-data                  # Cool comments
+      - &foo-i386
+        type: extra-data                  # Cool comments
         filename: UnityHubSetup.AppImage  # Very nice
         url: https://public-cdn.cloud.unity3d.com/hub/prod/UnityHubSetup.AppImage
         sha256: {UpdateEverythingChecker.CHECKSUM}
@@ -251,6 +255,8 @@ modules:
         size: {UpdateEverythingChecker.SIZE}
         only-arches:
           - x86_64
+
+      - *foo-i386
 
   - name: foo-32bit
     # Alias

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -330,6 +330,76 @@ sources:
             new_release=False,
         )
 
+    async def test_update_single_source(self):
+        filename = "foo-source.yaml"
+        contents = """
+type: extra-data
+filename: some-deb.deb
+url: https://phony-url.phony/some-deb_1.2.3.4-1_amd64.deb
+sha256: 0000000000000000000000000000000000000000000000000000000000000000
+size: 0
+""".lstrip()
+        expected_new_contents = f"""
+type: extra-data
+filename: some-deb.deb
+url: https://phony-url.phony/some-deb_1.2.3.4-1_amd64.deb
+sha256: {UpdateEverythingChecker.CHECKSUM}
+size: {UpdateEverythingChecker.SIZE}
+""".lstrip()
+        await self._test_update(
+            filename,
+            contents,
+            expected_new_contents,
+            ["Update some-deb.deb to 1.2.3.4"],
+            new_release=False,
+        )
+
+    async def test_update_sources(self):
+        filename = "foo-sources.json"
+        contents = """
+[
+    {
+        "type": "extra-data",
+        "filename": "some-deb.deb",
+        "url": "https://phony-url.phony/some-deb_1.2.3.4-1_amd64.deb",
+        "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+        "size": 0
+    },
+    {
+        "type": "extra-data",
+        "filename": "some-deb.deb",
+        "url": "https://phony-url.phony/some-deb_1.2.3.4-1_amd64.deb",
+        "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+        "size": 0
+    }
+]
+""".lstrip()
+        expected_new_contents = f"""
+[
+    {{
+        "type": "extra-data",
+        "filename": "some-deb.deb",
+        "url": "https://phony-url.phony/some-deb_1.2.3.4-1_amd64.deb",
+        "sha256": "{UpdateEverythingChecker.CHECKSUM}",
+        "size": {UpdateEverythingChecker.SIZE}
+    }},
+    {{
+        "type": "extra-data",
+        "filename": "some-deb.deb",
+        "url": "https://phony-url.phony/some-deb_1.2.3.4-1_amd64.deb",
+        "sha256": "{UpdateEverythingChecker.CHECKSUM}",
+        "size": {UpdateEverythingChecker.SIZE}
+    }}
+]""".lstrip()
+        await self._test_update(
+            filename,
+            contents,
+            expected_new_contents,
+            ["Update some-deb.deb to 1.2.3.4"],
+            expected_data_count=2,
+            new_release=False,
+        )
+
     async def test_check(self):
         checker = ManifestChecker(TEST_MANIFEST)
         ext_data = await checker.check()


### PR DESCRIPTION
Follow-up from #220 

Source collecting method is now recursive. As a side effect, it now allows multi-level nesting of external manifest files (i.e. `sources-A.json` can refer to `sources-B.json`, which can refer to `sources-C.json`, and so on).
I don't know if flatpak-builder allows (or is able to handle) this. I not, we can probably explicitly forbid nested external manifests.