### PR TITLE
Add --force-[no-]fork CLI parameters

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -171,7 +171,12 @@ AUTOMERGE_DUE_TO_BROKEN_URLS = (
 )
 
 
-def open_pr(subject, body, branch, manifest_checker=None):
+def open_pr(
+    subject: str,
+    body: str,
+    branch: str,
+    manifest_checker: checker.ManifestChecker = None,
+):
     try:
         github_token = os.environ["GITHUB_TOKEN"]
     except KeyError:

--- a/src/main.py
+++ b/src/main.py
@@ -253,7 +253,7 @@ def open_pr(
     for pr in open_prs:
         log.info("Found open PR: %s", pr.html_url)
 
-        if origin_repo.permissions.push and (automerge or force_automerge):
+        if automerge or force_automerge:
             pr_commit = pr.head.repo.get_commit(pr.head.sha)
             if pr_commit.get_combined_status().state == "success" and pr.mergeable:
                 log.info("PR passed CI and is mergeable, merging %s", pr.html_url)

--- a/src/main.py
+++ b/src/main.py
@@ -176,6 +176,7 @@ def open_pr(
     body: str,
     branch: str,
     manifest_checker: checker.ManifestChecker = None,
+    fork: t.Optional[bool] = None,
 ):
     try:
         github_token = os.environ["GITHUB_TOKEN"]
@@ -194,8 +195,14 @@ def open_pr(
     )
     origin_repo = g.get_repo(parse_github_url(origin_url))
 
-    if origin_repo.permissions.push:
-        log.debug("origin repo is writable")
+    if fork is True:
+        log.debug("creating fork (as requested)")
+        repo = user.create_fork(origin_repo)
+    elif fork is False:
+        log.debug("not creating fork (as requested)")
+        repo = origin_repo
+    elif origin_repo.permissions.push:
+        log.debug("origin repo is writable; not creating fork")
         repo = origin_repo
     else:
         log.debug("origin repo not writable; creating fork")
@@ -308,6 +315,33 @@ def parse_cli_args(cli_args=None):
         type=ExternalData.Type,
         choices=list(ExternalData.Type),
     )
+
+    fork = parser.add_argument_group(
+        "control forking behaviour",
+        "By default, %(prog)s pushes directly to the GitHub repo if the GitHub "
+        "token has permission to do so, and creates a fork if not.",
+    ).add_mutually_exclusive_group()
+    fork.add_argument(
+        "--always-fork",
+        action="store_const",
+        const=True,
+        dest="fork",
+        help=(
+            "Always push to a fork, even if the user has write access to the "
+            "upstream repo"
+        ),
+    )
+    fork.add_argument(
+        "--never-fork",
+        action="store_const",
+        const=False,
+        dest="fork",
+        help=(
+            "Never push to a fork, even if this means failing to push to the "
+            "upstream repo"
+        ),
+    )
+
     return parser.parse_args(cli_args)
 
 
@@ -329,7 +363,13 @@ async def run_with_args(args: argparse.Namespace) -> t.Tuple[int, int, bool]:
             with indir(os.path.dirname(args.manifest)):
                 subject, body, branch = commit_changes(changes)
                 if not args.commit_only:
-                    open_pr(subject, body, branch, manifest_checker=manifest_checker)
+                    open_pr(
+                        subject,
+                        body,
+                        branch,
+                        manifest_checker=manifest_checker,
+                        fork=args.fork,
+                    )
         did_update = True
 
     errors_num = print_errors(manifest_checker)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -42,3 +42,21 @@ class TestEntrypoint(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(await main.run_with_args(args1), (2, 0, True))
         args2 = main.parse_cli_args([self.manifest_path])
         self.assertEqual(await main.run_with_args(args2), (0, 0, False))
+
+
+class TestForceForkTristate(unittest.TestCase):
+    def test_neither_fork_arg(self):
+        args = main.parse_cli_args([TEST_MANIFEST])
+        self.assertIsNone(args.fork)
+
+    def test_always_fork_arg(self):
+        args = main.parse_cli_args(["--always-fork", TEST_MANIFEST])
+        self.assertTrue(args.fork)
+
+    def test_never_fork_arg(self):
+        args = main.parse_cli_args(["--never-fork", TEST_MANIFEST])
+        self.assertFalse(args.fork)
+
+    def test_both_fork_args(self):
+        with self.assertRaises(SystemExit):
+            main.parse_cli_args(["--always-fork", "--never-fork", TEST_MANIFEST])


### PR DESCRIPTION
I am trying to use this in GitHub Actions, with the default GITHUB_TOKEN
provided to the action. However, origin_repo.permissions.push is False.
Some digging suggests that this may be an artefact of the kind of token
being used here.[0] However, if we just go ahead and push and create the
CR directly to the repo, it works fine.

So, add a --force-no-fork CLI parameter to override the repository
permissions check, and a --force-fork parameter for symmetry. The
default is still to check the repository permissions. (Of course if you
--force-no-fork and you really don't have permission to push or create
PRs, you'll hit an error a few lines later.)

[0] https://github.com/endlessm/eos-google-chrome-app/pull/96
