### PR TITLE
jsonchecker: Allow specifying a different data url for each query

### DIFF
--- a/src/checkers/jsonchecker.py
+++ b/src/checkers/jsonchecker.py
@@ -17,15 +17,14 @@ from .htmlchecker import HTMLChecker
 log = logging.getLogger(__name__)
 
 
-async def query_json(query, data, variables=None):
+async def query_json(query: str, data: bytes, variables: t.Dict[str, str]) -> str:
     typecheck_q = (
         '.|type as $rt | if $rt=="string" or $rt=="number" then . else error($rt) end'
     )
 
     var_args = []
-    if variables is not None:
-        for var_name, var_value in variables.items():
-            var_args += ["--arg", var_name, var_value]
+    for var_name, var_value in variables.items():
+        var_args += ["--arg", var_name, var_value]
 
     jq_cmd = ["jq"] + var_args + ["-r", "-e", f"( {query} ) | ( {typecheck_q} )"]
     try:
@@ -35,8 +34,10 @@ async def query_json(query, data, variables=None):
     return jq_stdout.decode().strip()
 
 
-async def query_sequence(json_data, queries):
-    results = {}
+async def query_sequence(
+    json_data: bytes, queries: t.List[t.Tuple[str, t.Optional[str]]]
+) -> t.Dict[str, str]:
+    results: t.Dict[str, str] = {}
     for result_key, query in queries:
         if not query:
             continue

--- a/tests/io.github.stedolan.jq.yml
+++ b/tests/io.github.stedolan.jq.yml
@@ -36,6 +36,18 @@ modules:
           tag-query: '.tag_name'
           version-query: '.tag_name | sub("^[vV]"; "")'
 
+  - name: openal-soft
+    sources:
+      - type: git
+        url: https://github.com/kcat/openal-soft.git
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/kcat/openal-soft/git/refs/tags
+          commit-query: last | .object.sha
+          tag-query: last | .ref | split("/") | last
+          timestamp-data-url: last | .object.url
+          timestamp-query: .committer.date
+
   - name: tdesktop
     sources:
       - type: git

--- a/tests/test_jsonchecker.py
+++ b/tests/test_jsonchecker.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+import datetime
 
 from src.checker import ManifestChecker
 from src.lib.utils import init_logging
@@ -16,7 +17,7 @@ class TestJSONChecker(unittest.IsolatedAsyncioTestCase):
         checker = ManifestChecker(TEST_MANIFEST)
         ext_data = await checker.check()
 
-        self.assertEqual(len(ext_data), 6)
+        self.assertEqual(len(ext_data), 7)
         for data in ext_data:
             self.assertIsNotNone(data)
             if data.filename == "jq-1.4.tar.gz":
@@ -56,6 +57,13 @@ class TestJSONChecker(unittest.IsolatedAsyncioTestCase):
                 self.assertNotEqual(data.new_version.tag, data.current_version.tag)
                 self.assertIsNotNone(data.new_version.version)
                 self.assertIsNone(data.new_version.timestamp)
+            elif data.filename == "openal-soft.git":
+                self.assertIsInstance(data.new_version, ExternalGitRef)
+                self.assertEqual(data.current_version.url, data.new_version.url)
+                self.assertIsNotNone(data.new_version.tag)
+                self.assertIsNotNone(data.new_version.commit)
+                self.assertIsNotNone(data.new_version.timestamp)
+                self.assertIsInstance(data.new_version.timestamp, datetime.datetime)
             elif data.filename == "tdesktop.git":
                 self.assertIsNone(data.new_version)
             elif data.filename == "lib_webrtc.git":


### PR DESCRIPTION
Sometimes the JSON data we get from a single URL doesn't contain all the values we need. This PR allows specifying alternate data URLs for each value (in form of jq expressions). If data url expression is set, it's be evaluated (with the original json data as input) and passed to the value expression instead of the the original json data.

This is useful e.g. for GitHub, which doesn't expose all the needed data on the same API endpoint, e.g. no timestamps on `/git/refs/tags` and no commit on `/releases`.

The x-checker-data syntax becomes ugly, thus I'm not sure if we should document it as is, or instead add a more readable "version 2" syntax for json checker.