### PR TITLE
Fix manifest update condition

### DIFF
--- a/src/checker.py
+++ b/src/checker.py
@@ -375,6 +375,7 @@ class ManifestChecker:
         ]
 
     def _update_manifest(self, path, datas, changes):
+        path_has_changes = False
         for data in datas:
             if data.new_version is None:
                 continue
@@ -388,8 +389,9 @@ class ManifestChecker:
                 message = "Update {}".format(data.filename)
 
             changes[message] = None
+            path_has_changes = True
 
-        if changes:
+        if path_has_changes:
             log.info("Updating %s", path)
             self._dump_manifest(path)
 


### PR DESCRIPTION
It appears that #216 is caused by what I presume to be a logical mistake in condition to dump manifest at given path: 
We decide to dump manifest if `changes` dict is not empty, but the dict contains _all_ changes across all manifests; thus, we dump the current manifest if there were _any_ changes in previous manifests.
Fix this by checking if we changed or not the current manifest.
Fixes #216