### PR TITLE
Validate source early

### DIFF
--- a/src/lib/errors.py
+++ b/src/lib/errors.py
@@ -26,6 +26,14 @@ class ManifestUpdateError(ManifestError):
     """Error updating flatpak-builder manifest"""
 
 
+class SourceLoadError(ManifestLoadError):
+    """Error loading flatpak-builder source item"""
+
+
+class SourceUnsupported(SourceLoadError):
+    """Don't know how to handle flatpak-builder source item"""
+
+
 class AppdataError(ManifestError):
     """Error processing metainfo.xml"""
 

--- a/tests/org.externaldatachecker.Manifest.json
+++ b/tests/org.externaldatachecker.Manifest.json
@@ -21,6 +21,12 @@
                     "url": "nowhere"
                 },
                 {
+                    "type": "extra-data",
+                    "filename": "invalid-checker-data",
+                    "url": "nowhere",
+                    "x-checker-data": [{}]
+                },
+                {
                     "type": "file",
                     "dest-filename": "ignoreme.txt",
                     "url": "https://httpbingo.org/status/200",


### PR DESCRIPTION
In case of schema errors in the manifest, f-e-d-c will usually throw an unhandled exception, which may not be easy for the user to figure out what's wrong.
Instead, validate source against a JSON schema as early as possible, and if the schema is invalid - print the error and skip such source.