### PR TITLE
refactor: Make source type a class attribute

### DIFF
--- a/src/lib/externaldata.py
+++ b/src/lib/externaldata.py
@@ -90,6 +90,7 @@ class ExternalBase(abc.ABC):
     current_version: t.Union[ExternalFile, ExternalGitRef]
     new_version: t.Optional[t.Union[ExternalFile, ExternalGitRef]]
     source: t.Mapping
+    source_path: str
     checker_data: t.Mapping
 
     @classmethod
@@ -178,7 +179,6 @@ class ExternalData(ExternalBase):
     def __init__(
         self,
         data_type: ExternalBase.Type,
-        source_path: str,
         filename: str,
         url: str,
         checksum: str = None,
@@ -186,7 +186,6 @@ class ExternalData(ExternalBase):
         arches=[],
         checker_data: dict = None,
     ):
-        self.source_path = source_path
         self.filename = filename
         self.arches = arches
         self.type = data_type
@@ -221,7 +220,6 @@ class ExternalData(ExternalBase):
 
         obj = cls(
             data_type,
-            source_path,
             name,
             url_str,
             sha256sum,
@@ -230,6 +228,7 @@ class ExternalData(ExternalBase):
             checker_data,
         )
         obj.source = source
+        obj.source_path = source_path
         return obj
 
     def update(self):
@@ -324,7 +323,6 @@ class ExternalGitRef(t.NamedTuple):
 class ExternalGitRepo(ExternalBase):
     def __init__(
         self,
-        source_path: str,
         repo_name: str,
         url: str,
         commit: str = None,
@@ -333,7 +331,6 @@ class ExternalGitRepo(ExternalBase):
         arches=[],
         checker_data=None,
     ):
-        self.source_path = source_path
         self.filename = repo_name
         self.arches = arches
         self.type = self.Type.GIT
@@ -357,7 +354,6 @@ class ExternalGitRepo(ExternalBase):
         arches = checker_data.get("arches") or source.get("only-arches") or ["x86_64"]
 
         obj = cls(
-            source_path,
             repo_name,
             url,
             commit,
@@ -367,6 +363,7 @@ class ExternalGitRepo(ExternalBase):
             checker_data,
         )
         obj.source = source
+        obj.source_path = source_path
         return obj
 
     def update(self):

--- a/src/lib/externaldata.py
+++ b/src/lib/externaldata.py
@@ -151,6 +151,9 @@ class ExternalBase(abc.ABC):
     def __str__(self):
         return f"{self.type.value} {self.filename}"
 
+    def __repr__(self):
+        return f"<{type(self).__name__} {self}>"
+
 
 class ExternalFile(t.NamedTuple):
     url: str


### PR DESCRIPTION
Use a single Python class to represent a single flatpak-builder source type.

This makes handling git type sources, which have a dedicated handler class, consistent with different file-like sources, which previously were handled by the same `ExternalData` class.
`.from_source()` class method now selects appropriate child class for handling given source.

We'll also need this change for some potential future changes:
- Handle type-specific source properties, e.g. `archive-type` for `archive` sources
- To implement source extracting, which is needed to run custom port-update hooks