### PR TITLE
refactor: Use common parent class for `External{File,GitRef}`

### DIFF
--- a/src/checker.py
+++ b/src/checker.py
@@ -427,7 +427,6 @@ class ManifestChecker:
             assert selected_data is not None
             log.warning("Guessed upstream source: %s", selected_data)
 
-        last_update: t.Union[ExternalFile, ExternalGitRef]
         last_update = selected_data.new_version
 
         version_changed = (

--- a/src/lib/externaldata.py
+++ b/src/lib/externaldata.py
@@ -112,9 +112,6 @@ class BuilderSource(abc.ABC):
         except ValueError as err:
             raise SourceUnsupported("Can't handle source") from err
 
-        if not source.get("url"):
-            raise SourceUnsupported('Data is not external: no "url" property')
-
         data_cls = cls.data_classes()[data_type]
 
         return data_cls.from_source_impl(source_path, source)
@@ -131,6 +128,14 @@ class ExternalBase(BuilderSource):
 
     current_version: t.Union[ExternalFile, ExternalGitRef]
     new_version: t.Optional[t.Union[ExternalFile, ExternalGitRef]]
+
+    @classmethod
+    def from_source(cls: t.Type[_BS], source_path: str, source: t.Dict) -> _BS:
+        if not source.get("url"):
+            raise SourceUnsupported('Data is not external: no "url" property')
+
+        # FIXME: https://github.com/python/mypy/issues/9282
+        return super().from_source(source_path, source)  # type: ignore
 
     def set_new_version(
         self, new_version: t.Union[ExternalFile, ExternalGitRef], is_update=None

--- a/src/lib/externaldata.py
+++ b/src/lib/externaldata.py
@@ -209,6 +209,9 @@ class ExternalFile(ExternalState):
 
 
 class ExternalData(ExternalBase):
+    current_version: ExternalFile
+    new_version: t.Optional[ExternalFile]
+
     def __init__(
         self,
         filename: str,
@@ -222,7 +225,6 @@ class ExternalData(ExternalBase):
         self.arches = arches
         self.checker_data = checker_data or {}
         assert size is None or isinstance(size, int)
-        self.current_version: ExternalFile
         self.current_version = ExternalFile(
             url=url,
             checksum=checksum,
@@ -230,7 +232,6 @@ class ExternalData(ExternalBase):
             version=None,
             timestamp=None,
         )
-        self.new_version: t.Optional[ExternalFile]
         self.new_version = None
         self.state = ExternalData.State.UNKNOWN
 
@@ -369,6 +370,9 @@ class ExternalGitRef(ExternalState):
 class ExternalGitRepo(ExternalBase):
     type = ExternalBase.Type.GIT
 
+    current_version: ExternalGitRef
+    new_version: t.Optional[ExternalGitRef]
+
     def __init__(
         self,
         repo_name: str,
@@ -382,7 +386,6 @@ class ExternalGitRepo(ExternalBase):
         self.filename = repo_name
         self.arches = arches
         self.checker_data = checker_data or {}
-        self.current_version: ExternalGitRef
         self.current_version = ExternalGitRef(
             url=url,
             commit=commit,
@@ -391,7 +394,6 @@ class ExternalGitRepo(ExternalBase):
             version=None,
             timestamp=None,
         )
-        self.new_version: t.Optional[ExternalGitRef]
         self.new_version = None
         self.state = ExternalGitRepo.State.UNKNOWN
 

--- a/src/lib/externaldata.py
+++ b/src/lib/externaldata.py
@@ -39,6 +39,8 @@ from .errors import (
     SourceUnsupported,
 )
 
+_BS = t.TypeVar("_BS", bound="ExternalBase")
+
 CHECKER_DATA_SCHEMA_COMMON = {
     "type": "object",
     "properties": {
@@ -94,7 +96,7 @@ class ExternalBase(abc.ABC):
     checker_data: t.Mapping
 
     @classmethod
-    def from_source(cls, source_path: str, source: t.Dict) -> ExternalBase:
+    def from_source(cls: t.Type[_BS], source_path: str, source: t.Dict) -> _BS:
         try:
             jsonschema.validate(source, cls.SOURCE_SCHEMA)
         except jsonschema.ValidationError as err:
@@ -113,7 +115,7 @@ class ExternalBase(abc.ABC):
         return data_cls.from_source_impl(source_path, source)
 
     @classmethod
-    def from_source_impl(cls, source_path: str, source: t.Dict) -> ExternalBase:
+    def from_source_impl(cls: t.Type[_BS], source_path: str, source: t.Dict) -> _BS:
         raise NotImplementedError
 
     def set_new_version(
@@ -141,7 +143,7 @@ class ExternalBase(abc.ABC):
             self.new_version = new_version
 
     @classmethod
-    def data_classes(cls) -> t.Dict[Type, t.Type[ExternalBase]]:
+    def data_classes(cls: t.Type[_BS]) -> t.Dict[Type, t.Type[_BS]]:
         classes = {}
         if hasattr(cls, "type"):
             classes[cls.type] = cls


### PR DESCRIPTION
Our current structure for handling source states doesn't scale well: `ExternalFile` and `ExternalGitRef` are completely independent from each other, so adding another source kind state handler will require a lot more changes than it should.
Fix this by using `dataclasses` instead of `NamedTuple`s, which can be easily inherited from a common parent class, and can be made lightweight and immutable just like tuples.