### PR TITLE
Make multi-type data checker schemas type-aware

### DIFF
--- a/src/checkers/anityachecker.py
+++ b/src/checkers/anityachecker.py
@@ -1,4 +1,5 @@
 import logging
+import typing as t
 
 from yarl import URL
 
@@ -28,12 +29,17 @@ class AnityaChecker(HTMLChecker):
             "url-template": {"type": "string"},
             "tag-template": {"type": "string"},
         },
-        "anyOf": [
-            {"required": ["project-id", "url-template"]},
-            {"required": ["project-id", "tag-template"]},
-        ],
     }
     SUPPORTED_DATA_CLASSES = [ExternalData, ExternalGitRepo]
+
+    @classmethod
+    def get_json_schema(cls, data_class: t.Type[ExternalBase]):
+        schema = super().get_json_schema(data_class).copy()
+        if issubclass(data_class, ExternalGitRepo):
+            schema["required"] = ["project-id", "tag-template"]
+        else:
+            schema["required"] = ["project-id", "url-template"]
+        return schema
 
     async def check(self, external_data: ExternalBase):
         assert self.should_check(external_data)

--- a/src/checkers/jsonchecker.py
+++ b/src/checkers/jsonchecker.py
@@ -64,12 +64,17 @@ class JSONChecker(HTMLChecker):
             "timestamp-data-url": {"type": "string"},
         },
         "required": ["url"],
-        "anyOf": [
-            {"required": ["version-query", "url-query"]},
-            {"required": ["tag-query"]},
-        ],
     }
     SUPPORTED_DATA_CLASSES = [ExternalData, ExternalGitRepo]
+
+    @classmethod
+    def get_json_schema(cls, data_class: t.Type[ExternalBase]):
+        schema = super().get_json_schema(data_class).copy()
+        if issubclass(data_class, ExternalGitRepo):
+            schema["required"] = ["tag-query"]
+        else:
+            schema["required"] = ["version-query", "url-query"]
+        return schema
 
     async def _get_json(self, url: t.Union[str, URL]) -> bytes:
         log.debug("Get JSON from %s", url)

--- a/src/lib/externaldata.py
+++ b/src/lib/externaldata.py
@@ -441,14 +441,15 @@ class Checker:
     def __init__(self, session: aiohttp.ClientSession):
         self.session = session
 
-    def get_json_schema(  # pylint: disable=unused-argument
-        self, external_data: ExternalBase
-    ) -> t.Dict[str, t.Any]:
-        if hasattr(self, "CHECKER_DATA_SCHEMA"):
-            return self.CHECKER_DATA_SCHEMA
-        raise NotImplementedError(
-            "If schema is not declared, this method must be overridden"
-        )
+    # pylint: disable=unused-argument
+    @classmethod
+    def get_json_schema(self, data_class: t.Type[ExternalBase]) -> t.Dict[str, t.Any]:
+        if not hasattr(self, "CHECKER_DATA_SCHEMA"):
+            raise NotImplementedError(
+                "If schema is not declared, this method must be overridden"
+            )
+
+        return self.CHECKER_DATA_SCHEMA
 
     @classmethod
     def should_check(cls, external_data: ExternalBase) -> bool:
@@ -463,7 +464,7 @@ class Checker:
 
     async def validate_checker_data(self, external_data: ExternalBase):
         assert any(isinstance(external_data, c) for c in self.SUPPORTED_DATA_CLASSES)
-        schema = self.get_json_schema(external_data)
+        schema = self.get_json_schema(type(external_data))
         if not schema:
             return
         try:


### PR DESCRIPTION
`x-checker-data` schema may differ depending on source type, e.g. AnityaChecker reuires `url-template` for file sources, but `tag-template` for git sources.
Generating json schema dynamically feels unclever, but I don't see another easy way to achieve this.