### PR TITLE
refactor: Make BuilderSource a dataclass

### DIFF
--- a/src/checker.py
+++ b/src/checker.py
@@ -347,7 +347,7 @@ class ManifestChecker:
             log.info("Checking %s external data items", counter.total)
             ext_data_checked = await asyncio.gather(*check_tasks)
 
-        return list(set(ext_data_checked))
+        return ext_data_checked
 
     def get_external_data(self, only_type=None) -> t.List[ExternalBase]:
         """Returns the list of the external data found in the manifest

--- a/src/checker.py
+++ b/src/checker.py
@@ -253,7 +253,7 @@ class ManifestChecker:
         counter: TasksCounter,
         http_session: aiohttp.ClientSession,
         data: ExternalBase,
-    ):
+    ) -> ExternalBase:
         src_rel_path = os.path.relpath(data.source_path, self._root_manifest_dir)
         counter.started += 1
         checkers = [c(http_session) for c in self._checkers if c.should_check(data)]
@@ -321,12 +321,13 @@ class ManifestChecker:
         )
         return data
 
-    async def check(self, filter_type=None):
+    async def check(self, filter_type=None) -> t.List[ExternalBase]:
         """Perform the check for all the external data in the manifest
 
         It initializes an internal list of all the external data objects
         found in the manifest.
         """
+        external_data: t.List[ExternalBase]
         external_data = sum(self._external_data.values(), [])
         if filter_type is not None:
             external_data = [d for d in external_data if d.type == filter_type]
@@ -348,7 +349,7 @@ class ManifestChecker:
 
         return list(set(ext_data_checked))
 
-    def get_external_data(self, only_type=None):
+    def get_external_data(self, only_type=None) -> t.List[ExternalBase]:
         """Returns the list of the external data found in the manifest
 
         Should be called after the 'check' method.
@@ -361,14 +362,17 @@ class ManifestChecker:
             if only_type is None or data.type == only_type
         ]
 
-    def get_errors(self, only_type: t.Optional[t.Type[Exception]] = None):
+    def get_errors(
+        self,
+        only_type: t.Optional[t.Type[Exception]] = None,
+    ) -> t.List[Exception]:
         """Return a list of errors occured while checking/updating the manifest"""
 
         return [
             e for e in self._errors if only_type is None or isinstance(e, only_type)
         ]
 
-    def get_outdated_external_data(self):
+    def get_outdated_external_data(self) -> t.List[ExternalBase]:
         """Returns a list of the outdated external data
 
         Outdated external data are the ones that either are broken
@@ -466,10 +470,11 @@ class ManifestChecker:
         else:
             log.debug("Version didn't change, not adding release")
 
-    def update_manifests(self):
+    def update_manifests(self) -> t.List[str]:
         """Updates references to external data in manifests."""
         # We want a list, without duplicates; Python provides an
         # insertion-order-preserving dictionary so we use that.
+        changes: t.Dict[str, t.Any]
         changes = OrderedDict()
         for path, datas in self._external_data.items():
             self._update_manifest(path, datas, changes)

--- a/src/lib/externaldata.py
+++ b/src/lib/externaldata.py
@@ -58,6 +58,7 @@ CHECKER_DATA_SCHEMA_COMMON = {
 log = logging.getLogger(__name__)
 
 
+@dataclasses.dataclass
 class BuilderSource(abc.ABC):
     """flatpak-builder source item"""
 
@@ -141,6 +142,7 @@ class ExternalState(abc.ABC):
         raise NotImplementedError
 
 
+@dataclasses.dataclass
 class ExternalBase(BuilderSource):
     """
     Abstract base for remote data sources, such as file or VCS repo
@@ -208,32 +210,10 @@ class ExternalFile(ExternalState):
         return self.url == other.url
 
 
+@dataclasses.dataclass
 class ExternalData(ExternalBase):
     current_version: ExternalFile
     new_version: t.Optional[ExternalFile]
-
-    def __init__(
-        self,
-        filename: str,
-        url: str,
-        checksum: str = None,
-        size: int = None,
-        arches=[],
-        checker_data: dict = None,
-    ):
-        self.filename = filename
-        self.arches = arches
-        self.checker_data = checker_data or {}
-        assert size is None or isinstance(size, int)
-        self.current_version = ExternalFile(
-            url=url,
-            checksum=checksum,
-            size=size,
-            version=None,
-            timestamp=None,
-        )
-        self.new_version = None
-        self.state = ExternalData.State.UNKNOWN
 
     @classmethod
     def from_source_impl(cls, source_path: str, source: t.Dict) -> ExternalData:
@@ -257,15 +237,21 @@ class ExternalData(ExternalBase):
         arches = checker_data.get("arches") or source.get("only-arches") or ["x86_64"]
 
         obj = cls(
+            cls.State.UNKNOWN,
             name,
-            url_str,
-            sha256sum,
-            size,
             arches,
+            source,
+            source_path,
             checker_data,
+            ExternalFile(
+                url=url_str,
+                checksum=sha256sum,
+                size=size,
+                version=None,
+                timestamp=None,
+            ),
+            None,
         )
-        obj.source = source
-        obj.source_path = source_path
         return obj
 
     def update(self):
@@ -285,14 +271,17 @@ class ExternalData(ExternalBase):
                 self.source.pop("size", None)
 
 
+@dataclasses.dataclass
 class FileSource(ExternalData):
     type = ExternalBase.Type.FILE
 
 
+@dataclasses.dataclass
 class ArchiveSource(ExternalData):
     type = ExternalBase.Type.ARCHIVE
 
 
+@dataclasses.dataclass
 class ExtraDataSource(ExternalData):
     type = ExternalBase.Type.EXTRA_DATA
 
@@ -367,35 +356,12 @@ class ExternalGitRef(ExternalState):
         )
 
 
+@dataclasses.dataclass
 class ExternalGitRepo(ExternalBase):
     type = ExternalBase.Type.GIT
 
     current_version: ExternalGitRef
     new_version: t.Optional[ExternalGitRef]
-
-    def __init__(
-        self,
-        repo_name: str,
-        url: str,
-        commit: str = None,
-        tag: str = None,
-        branch: str = None,
-        arches=[],
-        checker_data=None,
-    ):
-        self.filename = repo_name
-        self.arches = arches
-        self.checker_data = checker_data or {}
-        self.current_version = ExternalGitRef(
-            url=url,
-            commit=commit,
-            tag=tag,
-            branch=branch,
-            version=None,
-            timestamp=None,
-        )
-        self.new_version = None
-        self.state = ExternalGitRepo.State.UNKNOWN
 
     @classmethod
     def from_source_impl(cls, source_path, source) -> ExternalGitRepo:
@@ -410,16 +376,22 @@ class ExternalGitRepo(ExternalBase):
         arches = checker_data.get("arches") or source.get("only-arches") or ["x86_64"]
 
         obj = cls(
+            cls.State.UNKNOWN,
             repo_name,
-            url,
-            commit,
-            tag,
-            branch,
             arches,
+            source,
+            source_path,
             checker_data,
+            ExternalGitRef(
+                url=url,
+                commit=commit,
+                tag=tag,
+                branch=branch,
+                version=None,
+                timestamp=None,
+            ),
+            None,
         )
-        obj.source = source
-        obj.source_path = source_path
         return obj
 
     def update(self):

--- a/src/lib/externaldata.py
+++ b/src/lib/externaldata.py
@@ -84,8 +84,8 @@ class BuilderSource(abc.ABC):
         VALID = 1 << 1  # URL is reachable
         BROKEN = 1 << 2  # URL couldn't be reached
 
+    type: t.ClassVar[Type]
     state: State
-    type: Type
     filename: str
     arches: t.List[str]
     source: t.Mapping

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -93,7 +93,7 @@ class TestExternalDataChecker(unittest.IsolatedAsyncioTestCase):
         ext_data = await dummy_checker.check()
         ext_data_from_getter = dummy_checker.get_external_data()
         self.assertEqual(len(ext_data), len(ext_data_from_getter))
-        self.assertEqual(set(ext_data), set(ext_data_from_getter))
+        self.assertEqual(ext_data, ext_data_from_getter)
 
         self.assertEqual(len(ext_data), NUM_ALL_EXT_DATA)
         ext_data = await dummy_checker.check(ExternalData.Type.EXTRA_DATA)


### PR DESCRIPTION
`BuilderSource` subclassess `__init__` methods do nothing but add args to object attributes. We can get rid of the boilerplate code by using `dataclass` decorator for these classes.