### PR TITLE
Add a cli switch to enable unsafe features

### DIFF
--- a/src/checker.py
+++ b/src/checker.py
@@ -100,10 +100,12 @@ class ManifestChecker:
         failed: int = 0
         total: int = 0
 
-    def __init__(self, manifest: str):
+    def __init__(self, manifest: str, unsafe_enabled: bool = False):
         self.kind = self.Kind.UNKNOWN
         self.app_id: t.Optional[str]
         self.app_id = None
+
+        self.unsafe_enabled = unsafe_enabled
 
         self._root_manifest_path = manifest
         self._root_manifest_dir = os.path.dirname(self._root_manifest_path)

--- a/src/main.py
+++ b/src/main.py
@@ -341,6 +341,11 @@ def parse_cli_args(cli_args=None):
             "upstream repo"
         ),
     )
+    parser.add_argument(
+        "--unsafe",
+        help="Enable unsafe features; use only with manifests from trusted sources",
+        action="store_true",
+    )
 
     return parser.parse_args(cli_args)
 
@@ -351,7 +356,7 @@ async def run_with_args(args: argparse.Namespace) -> t.Tuple[int, int, bool]:
     should_update = args.update or args.commit_only or args.edit_only
     did_update = False
 
-    manifest_checker = checker.ManifestChecker(args.manifest)
+    manifest_checker = checker.ManifestChecker(args.manifest, args.unsafe)
 
     await manifest_checker.check(args.filter_type)
 


### PR DESCRIPTION
Adds an option to enable unsafe features, e.g. ones that involve arbitrary code execution.
Currently the option is propagated to `ManifestChecker` and does nothing; it'll be required to enable not-yet-implemented features like #222 and #252 