### PR TITLE
Respect some editorconfig settings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update && \
       python3-pyelftools \
       python3-semver \
       python3-jsonschema \
+      python3-editorconfig \
       squashfs-tools \
       ssh-client \
       jq \

--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ from the tool can be forcefully enabled by setting
 `automerge-flathubbot-prs` to `true` in `flathub.json`,
 or it can be completely disabled by setting `automerge-flathubbot-prs` to `false`.
 
+### Formatting manifests
+
+The tool respects some of [EditorConfig](https://editorconfig.org/) settings.
+If your preferred manifest formatting is different from the default (4-space indentation for JSON),
+create (and commit) a `.editorconfig` file near the manifest.
+
 ## Changes to Flatpak manifests
 
 For simple checks to see if a URL is broken, no changes are needed.  However,

--- a/README.md
+++ b/README.md
@@ -89,9 +89,21 @@ or it can be completely disabled by setting `automerge-flathubbot-prs` to `false
 
 ### Formatting manifests
 
-The tool respects some of [EditorConfig](https://editorconfig.org/) settings.
-If your preferred manifest formatting is different from the default (4-space indentation for JSON),
-create (and commit) a `.editorconfig` file near the manifest.
+When writing back JSON files, this tool defaults to four-space indentation, preserving or omitting a trailing newline based on the source file. If you prefer a different formatting, create and commit an `.editorconfig` file describing your preferred formatting for `.json` files. At present, this tool respects a subset of [EditorConfig](https://editorconfig.org/) settings:
+
+```ini
+root = true
+
+[*.json]
+indent_style = space
+# Only integer values are supported; ignored if indent_style=tab
+indent_size = 2
+insert_final_newline = true
+```
+
+Unfortunately, it is not feasible to preserve JSON-GLib's non-standard `/* */` syntax for comments. As an alternative, dictionary keys beginning with `//` are ignored by `flatpak-builder` and can be used for comments in many cases.
+
+For YAML files, this tool attempts to preserve existing formatting and comments automatically. `.editorconfig` is not used.
 
 ## Changes to Flatpak manifests
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pyelftools
 aiohttp
 semver
 jsonschema
+editorconfig

--- a/src/lib/utils.py
+++ b/src/lib/utils.py
@@ -19,7 +19,6 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 import datetime as dt
-import glob
 import hashlib
 import json
 import logging
@@ -34,6 +33,7 @@ import typing as t
 from distutils.version import StrictVersion, LooseVersion
 import asyncio
 import shlex
+from pathlib import Path
 
 from collections import OrderedDict
 from ruamel.yaml import YAML
@@ -360,9 +360,9 @@ async def extract_appimage_version(appimg_io: t.IO):
         log.info("Running %s", unsquashfs_cmd)
         await unsquashfs_cmd.run()
 
-        for desktop in glob.glob(os.path.join(tmpdir, "squashfs-root", "*.desktop")):
+        for desktop in (Path(tmpdir) / "squashfs-root").glob("*.desktop"):
             kf = GLib.KeyFile()
-            kf.load_from_file(desktop, GLib.KeyFileFlags.NONE)
+            kf.load_from_file(str(desktop), GLib.KeyFileFlags.NONE)
             return kf.get_string(GLib.KEY_FILE_DESKTOP_GROUP, "X-AppImage-Version")
 
 
@@ -391,7 +391,7 @@ def parse_github_url(url):
         raise ValueError(f"{url!r} doesn't look like a Git URL")
 
 
-def read_json_manifest(manifest_path):
+def read_json_manifest(manifest_path: Path):
     """Read manifest from 'manifest_path', which may contain C-style
     comments or multi-line strings (accepted by json-glib and hence
     flatpak-builder, but not Python's json module)."""
@@ -400,7 +400,7 @@ def read_json_manifest(manifest_path):
     # strings, and any other invalid JSON
     parser = Json.Parser()
     try:
-        parser.load_from_file(manifest_path)
+        parser.load_from_file(str(manifest_path))
     except GLib.Error as err:
         if err.matches(GLib.file_error_quark(), GLib.FileError.NOENT):
             raise FileNotFoundError(err.message) from err  # pylint: disable=no-member
@@ -418,32 +418,32 @@ _yaml = YAML()
 _yaml.indent(mapping=2, sequence=4, offset=2)
 
 
-def read_yaml_manifest(manifest_path):
+def read_yaml_manifest(manifest_path: Path):
     """Read a YAML manifest from 'manifest_path'."""
-    with open(manifest_path, "r") as f:
+    with manifest_path.open("r") as f:
         return _yaml.load(f)
 
 
-def read_manifest(manifest_path):
+def read_manifest(manifest_path: t.Union[Path, str]):
     """Reads a JSON or YAML manifest from 'manifest_path'."""
-    _, ext = os.path.splitext(manifest_path)
-    if ext in (".yaml", ".yml"):
+    manifest_path = Path(manifest_path)
+    if manifest_path.suffix in (".yaml", ".yml"):
         return read_yaml_manifest(manifest_path)
     else:
         return read_json_manifest(manifest_path)
 
 
-def dump_manifest(contents, manifest_path):
+def dump_manifest(contents: t.Dict, manifest_path: t.Union[Path, str]):
     """Writes back 'contents' to 'manifest_path'.
 
     For YAML, we make a best-effort attempt to preserve
     formatting; for JSON, we use the canonical 4-space indentation,
     but add a trailing newline if originally present."""
-    _, ext = os.path.splitext(manifest_path)
-    with open(manifest_path, "r") as fp:
+    manifest_path = Path(manifest_path)
+    with manifest_path.open("r") as fp:
         newline = _check_newline(fp)
-    with open(manifest_path, "w", encoding="utf-8") as fp:
-        if ext in (".yaml", ".yml"):
+    with manifest_path.open("w", encoding="utf-8") as fp:
+        if manifest_path.suffix in (".yaml", ".yml"):
             _yaml.dump(contents, fp)
         else:
             json.dump(obj=contents, fp=fp, indent=4)


### PR DESCRIPTION
We can use the editorconfig library to get settings for a manifest we're about to dump, and, depending on it, ajust indentation style and size (in case of spaces), and determine if we should add trailing newline.

Fixes #262 
Closes #256
Adds another way to address #209