### PR TITLE
lib/utils: Catch type errors on loose version comparison

### DIFF
--- a/src/lib/utils.py
+++ b/src/lib/utils.py
@@ -156,7 +156,14 @@ def filter_versions(
             try:
                 match = oper(StrictVersion(version_str), StrictVersion(version_limit))
             except ValueError:
-                match = oper(LooseVersion(version_str), LooseVersion(version_limit))
+                try:
+                    match = oper(LooseVersion(version_str), LooseVersion(version_limit))
+                except TypeError as err:
+                    log.debug(
+                        "Comparison of loose versions failed due to type mismatch: %s",
+                        err,
+                    )
+                    match = False
             matches.append(match)
         if all(matches):
             new_versions.append(version)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -154,6 +154,10 @@ class TestVersionFilter(unittest.TestCase):
             filter_versions(["1.a", "1.b", "1.c"], [(">=", "1.b")]),
             ["1.b", "1.c"],
         )
+        self.assertEqual(
+            filter_versions(["3.1.0", "2.2.0", "1.12.0", "start"], [("<", "2.0.0")]),
+            ["1.12.0"],
+        )
 
     def test_sort(self):
         self.assertEqual(


### PR DESCRIPTION
Some software[0] does not strictly use numbers or semantic versioning
for labeling tags/releases in git. Trying to filter out these versions
would lead to TypeError due to comparison between int and str (str being
the non-compliant version string). Catch this error and due to no
reliable of checking the version, mark it as a non-match.

[0] https://release-monitoring.org/project/13289/