### PR TITLE
appdata: Rewrite appdata updater using lxml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update && \
       python3-semver \
       python3-jsonschema \
       python3-editorconfig \
+      python3-lxml \
       squashfs-tools \
       ssh-client \
       jq \

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ aiohttp
 semver
 jsonschema
 editorconfig
+lxml

--- a/src/checker.py
+++ b/src/checker.py
@@ -24,8 +24,11 @@ import typing as t
 import asyncio
 from dataclasses import dataclass
 from enum import IntEnum
+import logging
+import os
 
 import aiohttp
+from lxml.etree import XMLSyntaxError
 
 from .checkers import ALL_CHECKERS
 from .lib import HTTP_CLIENT_HEADERS, TIMEOUT_CONNECT, TIMEOUT_TOTAL
@@ -46,10 +49,6 @@ from .lib.errors import (
     SourceLoadError,
     SourceUnsupported,
 )
-
-import logging
-import os
-from xml.sax import SAXParseException
 
 
 MAIN_SRC_PROP = "is-main-source"
@@ -466,9 +465,8 @@ class ManifestChecker:
                 add_release_to_file(
                     appdata, last_update.version, timestamp.strftime("%F")
                 )
-            except SAXParseException as err:
-                # XXX: Pylint thinks that SAXParseException isn't an Exception, why?
-                raise AppdataLoadError from err  # pylint: disable=bad-exception-context
+            except XMLSyntaxError as err:
+                raise AppdataLoadError from err
         else:
             log.debug("Version didn't change, not adding release")
 

--- a/tests/test_appdata.py
+++ b/tests/test_appdata.py
@@ -19,17 +19,18 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 import unittest
-from io import StringIO
+from io import BytesIO
 
 from src.lib.appdata import add_release
 
 
 class TestAddRelease(unittest.TestCase):
     def _do_test(self, before, expected):
-        in_ = StringIO(before)
-        out = StringIO()
+        in_ = BytesIO(before.encode())
+        out = BytesIO()
         add_release(in_, out, "4.5.6", "2020-02-02")
-        self.assertMultiLineEqual(out.getvalue(), expected)
+        # FIXME lxml pretty print always adds trailing newline
+        self.assertMultiLineEqual(expected + "\n", out.getvalue().decode())
 
     def test_simple(self):
         self._do_test(
@@ -172,6 +173,7 @@ class TestAddRelease(unittest.TestCase):
 EmailAddress: billg@example.com
 SentUpstream: 2014-05-22
 -->
+  <name>First element needed</name>
 </application>
             """.strip(),
             """
@@ -182,6 +184,7 @@ SentUpstream: 2014-05-22
 EmailAddress: billg@example.com
 SentUpstream: 2014-05-22
 -->
+  <name>First element needed</name>
   <releases>
     <release version="4.5.6" date="2020-02-02"/>
   </releases>


### PR DESCRIPTION
lxml can preserve most of the XML formatting OOTB, including comments, so we need much less code to handle indentation for newely added nodes.
This patch also separates XML structure changes logic from formatting.
Trailing newlines currently aren't preserved (they're always added instead). No other behaviour changes expected.

This is the first step needed to allow re-indenting appdata XMLs (which, in turn, will allow us to support and editorconfig for appdata, and ultimately implement #222).