### PR TITLE
Revert no http decoding

### DIFF
--- a/src/lib/utils.py
+++ b/src/lib/utils.py
@@ -115,7 +115,6 @@ async def get_extra_data_info_from_url(
         trace_configs=session.trace_configs,
         timeout=session.timeout,
         headers=session.headers,
-        skip_auto_headers=[aiohttp.hdrs.ACCEPT_ENCODING],
         raise_for_status=True,
         auto_decompress=False,
     ) as new_session:

--- a/tests/org.externaldatachecker.Manifest.json
+++ b/tests/org.externaldatachecker.Manifest.json
@@ -75,7 +75,7 @@
                 {
                     "type": "extra-data",
                     "filename": "hogs.txt",
-                    "url": "https://httpbin.org/base64/MzAtNTAgZmVyYWwgaG9ncyEK",
+                    "url": "https://httpbingo.org/base64/MzAtNTAgZmVyYWwgaG9ncyEK",
                     "sha256": "e4d67702da4eeeb2f15629b65bf6767c028a511839c14ed44d9f34479eaa2b94",
                     "size": 18
                 },

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -23,8 +23,6 @@ import logging
 import os
 import unittest
 import tempfile
-import hashlib
-import gzip
 
 from xml.dom import minidom
 
@@ -440,20 +438,11 @@ size: {UpdateEverythingChecker.SIZE}
             relative_redirect.new_version.url,
             "https://httpbingo.org/base64/MzAtNTAgZmVyYWwgaG9ncyEK",
         )
-        # XXX: We can't tell httpbingo to encode or not the content. Currently it sends
-        # gzipped response, but check for and accept plain response as well, just in case
-        hogs_data = "30-50 feral hogs!\n".encode("ascii")
-        hogs_compr = gzip.compress(hogs_data, mtime=0, compresslevel=1)
-        self.assertIn(
+        self.assertEqual(
             relative_redirect.new_version.checksum,
-            [
-                hashlib.sha256(hogs_data).hexdigest(),
-                hashlib.sha256(hogs_compr).hexdigest(),
-            ],
+            "e4d67702da4eeeb2f15629b65bf6767c028a511839c14ed44d9f34479eaa2b94",
         )
-        self.assertIn(
-            relative_redirect.new_version.size, [len(hogs_data), len(hogs_compr)]
-        )
+        self.assertEqual(relative_redirect.new_version.size, 18)
 
         # this URL is a redirect, but since it is not a rotating-url the URL
         # should not be updated.


### PR DESCRIPTION
Since Flatpak version 1.12.3, it now properly handles encoded HTTP content for extra-data, i.e. decodes it on the fly (see flatpak/flatpak#4430). So our workaround isn't needed anymore, and we'll match newer flatpak behaviour if we revert it.