### PR TITLE
Electron Auto Update checker

### DIFF
--- a/src/checkers/__init__.py
+++ b/src/checkers/__init__.py
@@ -11,6 +11,7 @@ from .gitchecker import GitChecker
 from .pypichecker import PyPIChecker
 from .gnomechecker import GNOMEChecker
 from .chromiumchecker import ChromiumChecker
+from .electronchecker import ElectronChecker
 
 
 # For each ExternalData, checkers are run in the order listed here, stopping once data.state is
@@ -27,6 +28,7 @@ ALL_CHECKERS = [
     PyPIChecker,
     GNOMEChecker,
     ChromiumChecker,
+    ElectronChecker,
     GitChecker,  # leave this last but one
     URLChecker,  # leave this last
 ]

--- a/src/checkers/electronchecker.py
+++ b/src/checkers/electronchecker.py
@@ -1,0 +1,83 @@
+import logging
+import base64
+from datetime import datetime
+import typing as t
+
+from yarl import URL
+import ruamel.yaml
+
+from ..lib import NETWORK_ERRORS
+from ..lib.externaldata import (
+    Checker,
+    ExternalBase,
+    ExternalData,
+    ExternalFile,
+)
+from ..lib.errors import CheckerQueryError
+from ..lib.checksums import MultiDigest
+from .jsonchecker import parse_timestamp
+
+yaml = ruamel.yaml.YAML(typ="safe")
+log = logging.getLogger(__name__)
+
+
+class ElectronChecker(Checker):
+    CHECKER_DATA_TYPE = "electron-updater"
+    CHECKER_DATA_SCHEMA = {
+        "type": "object",
+        "properties": {
+            "url": {"type": "string", "format": "uri"},
+        },
+    }
+
+    @staticmethod
+    def _read_digests(obj: t.Dict) -> MultiDigest:
+        digests: t.Dict[str, str] = {}
+        for _k in MultiDigest._fields:  # pylint: disable=no-member
+            if _k in obj:
+                digests[_k] = base64.b64decode(obj[_k]).hex()
+        return MultiDigest(**digests)
+
+    async def check(self, external_data: ExternalBase):
+        assert isinstance(external_data, ExternalData)
+
+        if "url" in external_data.checker_data:
+            metadata_url = URL(external_data.checker_data["url"])
+        else:
+            metadata_url = URL(external_data.current_version.url).join(
+                URL("latest-linux.yml")
+            )
+
+        try:
+            async with self.session.get(metadata_url) as resp:
+                metadata = yaml.load(await resp.read())
+        except NETWORK_ERRORS as err:
+            raise CheckerQueryError from err
+
+        if "files" in metadata:
+            # Modern metadata format
+            m_file = metadata["files"][0]
+            file_url = metadata_url.join(URL(m_file["url"]))
+            file_size = int(m_file["size"])
+            checksum = self._read_digests(m_file)
+        else:
+            # Old electron-updater 1.x metadata format; no size property
+            file_url = metadata_url.join(URL(metadata["path"]))
+            file_size = None
+            checksum = self._read_digests(metadata)
+
+        timestamp: t.Optional[datetime]
+        if isinstance(metadata["releaseDate"], datetime):
+            timestamp = metadata["releaseDate"]
+        else:
+            timestamp = parse_timestamp(metadata["releaseDate"])
+
+        new_version = ExternalFile(
+            url=str(file_url),
+            checksum=checksum,
+            size=file_size,
+            version=metadata["version"],
+            timestamp=timestamp,
+        )
+
+        await self._set_new_version(external_data, new_version)

--- a/src/lib/checksums.py
+++ b/src/lib/checksums.py
@@ -23,6 +23,11 @@ class MultiDigest(t.NamedTuple):
         assert digests, source
         return cls(**digests)
 
+    @property
+    def digests(self) -> t.Set[str]:
+        # pylint: disable=no-member
+        return {k for k in self._fields if getattr(self, k) is not None}
+
     def __eq__(self, other):
         assert isinstance(other, type(self)), other
         # Iterate digest types from strongest to weakest,

--- a/src/lib/externaldata.py
+++ b/src/lib/externaldata.py
@@ -30,14 +30,14 @@ import aiohttp
 from yarl import URL
 import jsonschema
 
-from . import utils, FILE_URL_SCHEMES
+from . import utils, FILE_URL_SCHEMES, NETWORK_ERRORS
 from .errors import (
     CheckerMetadataError,
     CheckerFetchError,
     SourceLoadError,
     SourceUnsupported,
 )
-from .checksums import MultiDigest
+from .checksums import MultiDigest, MultiHash
 
 _BS = t.TypeVar("_BS", bound="BuilderSource")
 _ES = t.TypeVar("_ES", bound="ExternalState")
@@ -454,3 +454,50 @@ class Checker:
 
     async def check(self, external_data: ExternalBase):
         raise NotImplementedError
+
+    # Various helplers for checkers; assumed to be safely usable only from subclasses
+
+    async def _complete_digests(
+        self, url: t.Union[str, URL], digests: MultiDigest
+    ) -> MultiDigest:
+        """
+        Re-download given `url`, verify it against given `digests`,
+        and return a `MultiDigest` with all digest types set.
+        """
+        multihash = MultiHash()
+        try:
+            async with self.session.get(url) as resp:
+                async for chunk, _ in resp.content.iter_chunks():
+                    multihash.update(chunk)
+        except NETWORK_ERRORS as err:
+            raise CheckerFetchError from err
+        new_digests = multihash.hexdigest()
+        if new_digests != digests:
+            raise CheckerFetchError(
+                f"Checksum mismatch for {url}: "
+                f"expected {digests}, got {new_digests}"
+            )
+        return new_digests
+
+    async def _set_new_version(self, source: ExternalBase, new_version: ExternalState):
+        """
+        Set the `new_version` for `source`, ensuring common digest types are set.
+        """
+        if (
+            isinstance(source, ExternalData) and isinstance(new_version, ExternalFile)
+        ) and not (
+            source.current_version.checksum.digests & new_version.checksum.digests
+        ):
+            log.warning(
+                "Source %s: %s didn't get a %s digest; available digests were %s",
+                source,
+                self.__class__.__name__,
+                source.current_version.checksum.digests,
+                new_version.checksum.digests,
+            )
+            checksum = await self._complete_digests(
+                new_version.url, new_version.checksum
+            )
+            new_version = new_version._replace(checksum=checksum)
+
+        source.set_new_version(new_version)

--- a/tests/fedc.test.ElectronChecker.yml
+++ b/tests/fedc.test.ElectronChecker.yml
@@ -1,0 +1,19 @@
+id: fedc.test.ElectronChecker
+modules:
+  - name: etcher
+    sources:
+      - type: file
+        url: https://github.com/balena-io/etcher/releases/download/v1.7.2/balenaEtcher-1.7.2-x64.AppImage
+        sha512: 360142fb3e6a0b67f17f2cd1bf90e8c9663a5e4658bae9ed754081315fa8034d68cddffa6419ae4bde5eb60a9ccfed8c8236c9a939cd5b1f9131e28bdf3924c2
+        x-checker-data:
+          type: electron-updater
+          url: https://github.com/balena-io/etcher/releases/latest/download/latest-linux.yml
+  
+  - name: Lunar-Client
+    sources:
+      - type: extra-data
+        url: https://launcherupdates.lunarclientcdn.com/Lunar%20Client-2.9.2.AppImage
+        sha256: a005879b62395fe71d7ad5b01ee7fc7fe43b59629bd83f23cee35380a13ba8c8
+        x-checker-data:
+          type: electron-updater
+          url: https://launcherupdates.lunarclientcdn.com/latest-linux.yml

--- a/tests/test_electronchecker.py
+++ b/tests/test_electronchecker.py
@@ -1,0 +1,27 @@
+import os
+import unittest
+import datetime
+
+from src.checker import ManifestChecker
+from src.lib.utils import init_logging
+from src.lib.checksums import MultiDigest
+
+TEST_MANIFEST = os.path.join(os.path.dirname(__file__), "fedc.test.ElectronChecker.yml")
+
+
+class TestElectronChecker(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        init_logging()
+
+    async def test_check(self):
+        checker = ManifestChecker(TEST_MANIFEST)
+        ext_data = await checker.check()
+        for data in ext_data:
+            self.assertIsNotNone(data)
+            self.assertIsNotNone(data.new_version)
+            self.assertIsInstance(data.new_version.url, str)
+            self.assertIsInstance(data.new_version.checksum, MultiDigest)
+            self.assertIsInstance(data.new_version.size, int)
+            self.assertIsInstance(data.new_version.version, str)
+            self.assertIsInstance(data.new_version.timestamp, datetime.date)
+            self.assertNotEqual(data.new_version.url, data.current_version.url)


### PR DESCRIPTION
Electron has an [auto-update mechanism](https://www.electron.build/auto-update.html), which relies on remotely stored metadata file (e.g. `latest-linux.yml`). We can use this metadata, too.
This is the first checker to rely on #208, since the electron-updater metadata seem to usually contain only sha512 checksums.
Closes #268 