### PR TITLE
htmlchecker: Prevent charset detection on large non-text files

### DIFF
--- a/src/checkers/htmlchecker.py
+++ b/src/checkers/htmlchecker.py
@@ -101,6 +101,13 @@ class HTMLChecker(Checker):
         ],
     }
 
+    async def _get_text(self, url: t.Union[URL, str]) -> str:
+        try:
+            async with self.session.get(url) as response:
+                return await response.text()
+        except NETWORK_ERRORS as err:
+            raise CheckerQueryError from err
+
     async def check(self, external_data: ExternalBase):
         assert self.should_check(external_data)
         assert isinstance(external_data, ExternalData)
@@ -113,11 +120,7 @@ class HTMLChecker(Checker):
         sort_matches = external_data.checker_data.get("sort-matches", True)
         assert combo_pattern or (version_pattern and (url_pattern or url_template))
 
-        try:
-            async with self.session.get(url) as response:
-                html = await response.text()
-        except NETWORK_ERRORS as err:
-            raise CheckerQueryError from err
+        html = await self._get_text(url)
 
         if combo_pattern:
             latest_url, latest_version = _get_latest(

--- a/tests/test_htmlchecker.py
+++ b/tests/test_htmlchecker.py
@@ -31,6 +31,7 @@ from src.lib.utils import init_logging
 from src.checker import ManifestChecker
 from src.lib.checksums import MultiDigest
 from src.checkers import HTMLChecker
+from src.lib.errors import CheckerError
 
 
 class TestHTMLTools(unittest.IsolatedAsyncioTestCase):
@@ -61,6 +62,9 @@ class TestHTMLTools(unittest.IsolatedAsyncioTestCase):
                 await checker._get_text(self._encoded_url(sample.encode(charset))),
                 sample,
             )
+
+        with self.assertRaises(CheckerError):
+            await checker._get_text("https://httpbin.org/image/jpeg")
 
 
 TEST_MANIFEST = os.path.join(os.path.dirname(__file__), "org.x.xeyes.yml")


### PR DESCRIPTION
Fixes #271 