### PR TITLE
Fix run-in-container wrapper script and associated instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,9 +41,6 @@ whose only dependency is the `podman` command:
 # Run one suite of tests
 ./run-in-container.sh python3 -m unittest tests.test_appdata
 
-# Apply code formatting
-./run-in-container.sh black .
-
 # More information
 ./run-in-container.sh python3 -m unittest --help
 ```

--- a/run-in-container.sh
+++ b/run-in-container.sh
@@ -6,6 +6,13 @@ GIT_USER_EMAIL=$(git config user.email)
 
 CWD=$(pwd)
 
+PYTHON_ENTRYPOINT=""
+
+if [ "$1" == "python3" ]; then
+    PYTHON_ENTRYPOINT="--entrypoint=python3"
+    shift # don't pass first argument since setting entrypoint
+fi
+
 podman run --rm --privileged \
     -v $HOME:$HOME:rslave \
     -v $CWD:$CWD:rslave \
@@ -14,5 +21,6 @@ podman run --rm --privileged \
     -e GIT_COMMITTER_NAME="$GIT_USER_NAME" \
     -e GIT_AUTHOR_EMAIL="$GIT_USER_EMAIL" \
     -e GIT_COMMITTER_EMAIL="$GIT_USER_EMAIL" \
+    $PYTHON_ENTRYPOINT \
     -it ghcr.io/flathub/flatpak-external-data-checker \
     $*


### PR DESCRIPTION
The container image was adapted for local use in 064fdeaa85e00bf72832d1991a571b4e009137ae, which means the default entrypoint is f-e-d-c itself.
However, test suites from CONTRIBUTING.md don't run, since they need to be run from python3 normally. So fix by setting entrypoint to python3 in the run-in-container wrapper script.

Black was removed since it is run by CI and no longer present in the image, and should be easy to install in a Toolbox or elsewhere.