### PR TITLE
Add support for selectively updating manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,12 @@ to Git and open a GitHub pull request. In order to do this, it requires
 a [GitHub access token](https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line),
 specified in the `GITHUB_TOKEN` environment variable.
 
+### Selectively submitting PRs
+
+The tool will by default open PRs if at least one source is updated. Alternatively, the tool can be configured to only open PRs if at least one "important" source is updated. This can avoid unwanted PRs, e.g. PRs that only update a single library.
+
+To only open PRs when at least one important source is updated, first set `require-important-update` to `true` in `flathub.json`. If using a custom workflow, instead pass `--require-important-update` to the tool. Then, set property `is-important` to `true` in the checker metadata for any important source(s). Sources with `is-main-source` in their checker metadata are also considered important.
+
 ### Automatically merging PRs
 
 The tool will also automatically merge previously opened pull request for

--- a/src/main.py
+++ b/src/main.py
@@ -392,6 +392,13 @@ def parse_cli_args(cli_args=None):
         type=int,
         default=manifest.MAX_MANIFEST_SIZE,
     )
+    parser.add_argument(
+        "--require-important-update",
+        help="Require an update to at least one source with is-important or is-main-source to save changes to the manifest. "
+        "If no instances of is-important or is-main-source are found, assume normal behaviour and always save changes to the manifest. "
+        "This is useful to avoid PRs generated to update a singular unimportant source.",
+        action="store_true",
+    )
 
     return parser.parse_args(cli_args)
 
@@ -405,6 +412,7 @@ async def run_with_args(args: argparse.Namespace) -> t.Tuple[int, int, bool]:
     options = manifest.CheckerOptions(
         allow_unsafe=args.unsafe,
         max_manifest_size=args.max_manifest_size,
+        require_important_update=args.require_important_update,
     )
 
     manifest_checker = manifest.ManifestChecker(args.manifest, options)

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -26,15 +26,18 @@ import tempfile
 import hashlib
 import base64
 from xml.dom import minidom
+import typing as t
 
 import aiohttp
 
 from src.lib.utils import init_logging
 from src.lib.externaldata import ExternalData
 from src.lib.checkers import Checker
+from src.checkers.gitchecker import GitChecker
+from src.lib.externaldata import ExternalGitRepo
 from src.lib.checksums import MultiDigest
 from src.lib.errors import CheckerFetchError
-from src.manifest import ManifestChecker
+from src import manifest
 
 TEST_MANIFEST = os.path.join(
     os.path.dirname(__file__),
@@ -84,30 +87,9 @@ class UpdateEverythingChecker(DummyChecker):
         )
 
 
-class TestExternalDataChecker(unittest.IsolatedAsyncioTestCase):
-    def setUp(self):
-        init_logging()
-
-    async def test_check_filtered(self):
-        # Use only the URLChecker which is fast so we don't have to wait a lot
-        # for this test; so save the real checkers for later
-        dummy_checker = ManifestChecker(TEST_MANIFEST)
-        dummy_checker._checkers = [DummyChecker]
-
-        ext_data = await dummy_checker.check()
-        ext_data_from_getter = dummy_checker.get_external_data()
-        self.assertEqual(len(ext_data), len(ext_data_from_getter))
-        self.assertEqual(ext_data, ext_data_from_getter)
-
-        self.assertEqual(len(ext_data), NUM_ALL_EXT_DATA)
-        ext_data = await dummy_checker.check(ExternalData.Type.EXTRA_DATA)
-        self.assertEqual(len(ext_data), NUM_EXTRA_DATA_IN_MANIFEST)
-
-        ext_data = await dummy_checker.check(ExternalData.Type.FILE)
-        self.assertEqual(len(ext_data), NUM_FILE_IN_MANIFEST)
-
-        ext_data = await dummy_checker.check(ExternalData.Type.ARCHIVE)
-        self.assertEqual(len(ext_data), NUM_ARCHIVE_IN_MANIFEST)
+class _TestWithInlineManifest(unittest.IsolatedAsyncioTestCase):
+    _DUMMY_CHECKER_CLS: t.Type[Checker]
+    maxDiff = None
 
     async def _test_update(
         self,
@@ -117,10 +99,11 @@ class TestExternalDataChecker(unittest.IsolatedAsyncioTestCase):
         expected_updates,
         expected_data_count=1,
         new_release=True,
+        require_important_update=False,
     ):
         with tempfile.TemporaryDirectory() as tmpdir:
-            manifest = os.path.join(tmpdir, filename)
-            with open(manifest, "w") as f:
+            manifest_path = os.path.join(tmpdir, filename)
+            with open(manifest_path, "w") as f:
                 f.write(contents)
 
             appdata = os.path.join(
@@ -130,16 +113,20 @@ class TestExternalDataChecker(unittest.IsolatedAsyncioTestCase):
             with open(appdata, "w") as f:
                 f.write("""<application></application>""")
 
-            checker = ManifestChecker(manifest)
+            options = manifest.CheckerOptions(
+                require_important_update=True,
+            )
+
+            checker = manifest.ManifestChecker(manifest_path, options)
             self.assertEqual(
                 len(checker.get_external_data()),
                 expected_data_count,
             )
-            checker._checkers = [UpdateEverythingChecker]
+            checker._checkers = [self._DUMMY_CHECKER_CLS]
             await checker.check()
             updates = checker.update_manifests()
 
-            with open(manifest, "r") as f:
+            with open(manifest_path, "r") as f:
                 new_contents = f.read()
 
             self.assertEqual(new_contents, expected_new_contents)
@@ -156,6 +143,34 @@ class TestExternalDataChecker(unittest.IsolatedAsyncioTestCase):
                 self.assertEqual(releases[0].getAttribute("date"), "2019-08-28")
             else:
                 self.assertEqual(releases, [])
+
+
+class TestExternalDataChecker(_TestWithInlineManifest):
+    _DUMMY_CHECKER_CLS = UpdateEverythingChecker
+
+    def setUp(self):
+        init_logging()
+
+    async def test_check_filtered(self):
+        # Use only the URLChecker which is fast so we don't have to wait a lot
+        # for this test; so save the real checkers for later
+        dummy_checker = manifest.ManifestChecker(TEST_MANIFEST)
+        dummy_checker._checkers = [DummyChecker]
+
+        ext_data = await dummy_checker.check()
+        ext_data_from_getter = dummy_checker.get_external_data()
+        self.assertEqual(len(ext_data), len(ext_data_from_getter))
+        self.assertEqual(ext_data, ext_data_from_getter)
+
+        self.assertEqual(len(ext_data), NUM_ALL_EXT_DATA)
+        ext_data = await dummy_checker.check(ExternalData.Type.EXTRA_DATA)
+        self.assertEqual(len(ext_data), NUM_EXTRA_DATA_IN_MANIFEST)
+
+        ext_data = await dummy_checker.check(ExternalData.Type.FILE)
+        self.assertEqual(len(ext_data), NUM_FILE_IN_MANIFEST)
+
+        ext_data = await dummy_checker.check(ExternalData.Type.ARCHIVE)
+        self.assertEqual(len(ext_data), NUM_ARCHIVE_IN_MANIFEST)
 
     async def test_update_json(self):
         filename = "com.example.App.json"
@@ -408,7 +423,7 @@ size: {UpdateEverythingChecker.SIZE}
         )
 
     async def test_check(self):
-        checker = ManifestChecker(TEST_MANIFEST)
+        checker = manifest.ManifestChecker(TEST_MANIFEST)
         ext_data = await checker.check()
 
         self.assertEqual(len(ext_data), NUM_ALL_EXT_DATA)
@@ -507,6 +522,611 @@ class TestCheckerHelpers(unittest.IsolatedAsyncioTestCase):
             await checker._complete_digests(
                 "https://httpbin.org/base64/status/404", MultiDigest(sha512=sha512)
             )
+
+
+class GitDummyChecker(GitChecker):
+    def get_json_schema(self, external_data):
+        return None
+
+    @classmethod
+    def should_check(cls, external_data):
+        return True
+
+    async def check(self, external_data):
+        logging.debug(
+            "Phony checker checking external data %s and all is always good",
+            external_data.filename,
+        )
+
+
+class GitUpdateEverythingChecker(GitDummyChecker):
+    # SIZE = 0
+    # echo -n | sha256sum
+    COMMIT = "abcdeadbeef00000000000000000000000000000"
+    TAG = "1.2.3.4"
+    TIMESTAMP = dt.date.fromisoformat("2019-08-28")
+
+    async def check(self, external_data):
+        external_data.state = ExternalGitRepo.State.UNKNOWN
+        new_version = external_data.current_version._replace(
+            commit=self.COMMIT,
+            tag=self.TAG,
+            version=self.TAG,
+            timestamp=self.TIMESTAMP,
+        )
+        if not external_data.current_version.matches(new_version):
+            external_data.new_version = new_version
+
+
+class TestImportantGitExternalDataChecker(_TestWithInlineManifest):
+    _DUMMY_CHECKER_CLS = GitUpdateEverythingChecker
+
+    def setUp(self):
+        init_logging()
+
+    async def test_update_no_important_source_updated(self):
+        """With two sources, while one source is updated it is not the important one,
+        so no manifest update should be made."""
+        filename = "importantsource.com.virustotal.Uploader.yml"
+        contents = """
+id: importantsource.com.virustotal.Uploader
+modules:
+  - name: extra-cmake-modules
+    sources:
+      - type: git
+        url: https://github.com/KDE/extra-cmake-modules
+        tag: 0.0.0.0
+        commit: 0000000000000000000000000000000000000000
+        x-checker-data:
+          type: git
+          tag-pattern: ^v(\d[\d.]+\d)$
+  - name: vt-py
+    sources:
+      # Current is valid, no updates
+      - type: git
+        url: https://github.com/VirusTotal/vt-py.git
+        tag: 1.2.3.4
+        commit: 0000000000000000000000000000000000000000
+        x-checker-data:
+          type: git
+          tag-pattern: ^(0.5.4)$
+          sort-tags: false
+          is-important: true
+          # since this is marked as the only important source, 
+          # but isn't getting updated, manifest should not be updated
+""".lstrip()
+        expected_new_contents = f"""
+id: importantsource.com.virustotal.Uploader
+modules:
+  - name: extra-cmake-modules
+    sources:
+      - type: git
+        url: https://github.com/KDE/extra-cmake-modules
+        tag: 0.0.0.0
+        commit: 0000000000000000000000000000000000000000
+        x-checker-data:
+          type: git
+          tag-pattern: ^v(\d[\d.]+\d)$
+  - name: vt-py
+    sources:
+      # Current is valid, no updates
+      - type: git
+        url: https://github.com/VirusTotal/vt-py.git
+        tag: 1.2.3.4
+        commit: 0000000000000000000000000000000000000000
+        x-checker-data:
+          type: git
+          tag-pattern: ^(0.5.4)$
+          sort-tags: false
+          is-important: true
+          # since this is marked as the only important source, 
+          # but isn't getting updated, manifest should not be updated
+""".lstrip()
+        await self._test_update(
+            filename=filename,
+            contents=contents,
+            expected_new_contents=expected_new_contents,
+            expected_updates=[],
+            expected_data_count=2,
+            new_release=False,
+            require_important_update=True,
+        )
+
+    async def test_update_one_important_source_updated(self):
+        """With two sources, one of them being important and updated, so a manifest update should be made."""
+        filename = "importantsource.com.virustotal.Uploader.yml"
+        contents = f"""
+id: importantsource.com.virustotal.Uploader
+modules:
+  - name: extra-cmake-modules
+    sources:
+      - type: git
+        url: https://github.com/KDE/extra-cmake-modules
+        tag: 0.0.0.0
+        commit: 0000000000000000000000000000000000000000
+        x-checker-data:
+          type: git
+          tag-pattern: ^(v5\.90\.0)$ # to ensure we only get this version
+          is-important: true
+          # since this is marked as the only important source, 
+          # and is actually getting updated, manifest should be updated
+  - name: vt-py
+    sources:
+      # Current is valid, no updates
+      - type: git
+        url: https://github.com/VirusTotal/vt-py.git
+        tag: {GitUpdateEverythingChecker.TAG}
+        commit: {GitUpdateEverythingChecker.COMMIT}
+        x-checker-data:
+          type: git
+          tag-pattern: ^(0.5.4)$
+          sort-tags: false
+""".lstrip()
+        expected_new_contents = f"""
+id: importantsource.com.virustotal.Uploader
+modules:
+  - name: extra-cmake-modules
+    sources:
+      - type: git
+        url: https://github.com/KDE/extra-cmake-modules
+        tag: {GitUpdateEverythingChecker.TAG}
+        commit: {GitUpdateEverythingChecker.COMMIT}
+        x-checker-data:
+          type: git
+          tag-pattern: ^(v5\.90\.0)$ # to ensure we only get this version
+          is-important: true
+          # since this is marked as the only important source, 
+          # and is actually getting updated, manifest should be updated
+  - name: vt-py
+    sources:
+      # Current is valid, no updates
+      - type: git
+        url: https://github.com/VirusTotal/vt-py.git
+        tag: {GitUpdateEverythingChecker.TAG}
+        commit: {GitUpdateEverythingChecker.COMMIT}
+        x-checker-data:
+          type: git
+          tag-pattern: ^(0.5.4)$
+          sort-tags: false
+""".lstrip()
+        await self._test_update(
+            filename=filename,
+            contents=contents,
+            expected_new_contents=expected_new_contents,
+            expected_updates=["Update extra-cmake-modules to 1.2.3.4"],
+            expected_data_count=2,
+            new_release=False,
+            require_important_update=True,
+        )
+
+    async def test_update_two_important_sources_first_updated(self):
+        """With two important sources, the first getting updated,
+        so a manifest update should be made.
+        Tests for correct looping (i.e. once it finds a singular important source that's updated it should update the manifest)."""
+        filename = "importantsource.com.virustotal.Uploader.yml"
+        contents = """
+id: importantsource.com.virustotal.Uploader
+modules:
+  - name: extra-cmake-modules
+    sources:
+      - type: git
+        url: https://github.com/KDE/extra-cmake-modules
+        tag: 0.0.0.0
+        commit: 0000000000000000000000000000000000000000
+        x-checker-data:
+          type: git
+          tag-pattern: ^(v5\.90\.0)$ # to ensure we only get this version
+          is-important: true
+          # since this is marked as a important source, 
+          # and is getting updated, manifest should be updated
+  - name: vt-py
+    sources:
+      # Current is valid, no updates
+      - type: git
+        url: https://github.com/VirusTotal/vt-py.git
+        tag: 1.2.3.4
+        commit: 0000000000000000000000000000000000000000
+        x-checker-data:
+          type: git
+          tag-pattern: ^(0.5.4)$
+          sort-tags: false
+          is-important: true 
+          # this is marked as important and not being updated, 
+          # yet the manifest should still be updated since the previous source is important and getting an update.
+""".lstrip()
+        expected_new_contents = f"""
+id: importantsource.com.virustotal.Uploader
+modules:
+  - name: extra-cmake-modules
+    sources:
+      - type: git
+        url: https://github.com/KDE/extra-cmake-modules
+        tag: {GitUpdateEverythingChecker.TAG}
+        commit: {GitUpdateEverythingChecker.COMMIT}
+        x-checker-data:
+          type: git
+          tag-pattern: ^(v5\.90\.0)$ # to ensure we only get this version
+          is-important: true
+          # since this is marked as a important source, 
+          # and is getting updated, manifest should be updated
+  - name: vt-py
+    sources:
+      # Current is valid, no updates
+      - type: git
+        url: https://github.com/VirusTotal/vt-py.git
+        tag: {GitUpdateEverythingChecker.TAG}
+        commit: {GitUpdateEverythingChecker.COMMIT}
+        x-checker-data:
+          type: git
+          tag-pattern: ^(0.5.4)$
+          sort-tags: false
+          is-important: true
+          # this is marked as important and not being updated, 
+          # yet the manifest should still be updated since the previous source is important and getting an update.
+""".lstrip()
+        await self._test_update(
+            filename=filename,
+            contents=contents,
+            expected_new_contents=expected_new_contents,
+            expected_updates=[
+                "Update extra-cmake-modules to 1.2.3.4",
+                "Update vt-py.git to 1.2.3.4",
+            ],
+            expected_data_count=2,
+            new_release=False,
+            require_important_update=True,
+        )
+
+    async def test_update_two_important_sources_second_updated(self):
+        """With two important sources, the second getting updated,
+        so a manifest update should be made.
+        Tests for correct looping (i.e. once it finds a singular important source that's updated it should update the manifest)."""
+        filename = "importantsource.com.virustotal.Uploader.yml"
+        contents = f"""
+id: importantsource.com.virustotal.Uploader
+modules:
+  - name: vt-py
+    sources:
+      # Current is valid, no updates
+      - type: git
+        url: https://github.com/VirusTotal/vt-py.git
+        tag: {GitUpdateEverythingChecker.TAG}
+        commit: {GitUpdateEverythingChecker.COMMIT}
+        x-checker-data:
+          type: git
+          tag-pattern: ^(0.5.4)$
+          sort-tags: false
+          is-important: true 
+          # this is marked as important and not being updated, 
+          # yet the manifest should still be updated since the next source is important and getting an update.
+  - name: extra-cmake-modules
+    sources:
+      - type: git
+        url: https://github.com/KDE/extra-cmake-modules
+        tag: 0.0.0.0
+        commit: 0000000000000000000000000000000000000000
+        x-checker-data:
+          type: git
+          tag-pattern: ^(v5\.90\.0)$ # to ensure we only get this version
+          is-important: true
+          # since this is marked as a important source, 
+          # and is getting updated, manifest should be updated
+""".lstrip()
+        expected_new_contents = f"""
+id: importantsource.com.virustotal.Uploader
+modules:
+  - name: vt-py
+    sources:
+      # Current is valid, no updates
+      - type: git
+        url: https://github.com/VirusTotal/vt-py.git
+        tag: {GitUpdateEverythingChecker.TAG}
+        commit: {GitUpdateEverythingChecker.COMMIT}
+        x-checker-data:
+          type: git
+          tag-pattern: ^(0.5.4)$
+          sort-tags: false
+          is-important: true
+          # this is marked as important and not being updated, 
+          # yet the manifest should still be updated since the next source is important and getting an update.
+  - name: extra-cmake-modules
+    sources:
+      - type: git
+        url: https://github.com/KDE/extra-cmake-modules
+        tag: {GitUpdateEverythingChecker.TAG}
+        commit: {GitUpdateEverythingChecker.COMMIT}
+        x-checker-data:
+          type: git
+          tag-pattern: ^(v5\.90\.0)$ # to ensure we only get this version
+          is-important: true
+          # since this is marked as a important source, 
+          # and is getting updated, manifest should be updated
+""".lstrip()
+        await self._test_update(
+            filename=filename,
+            contents=contents,
+            expected_new_contents=expected_new_contents,
+            expected_updates=["Update extra-cmake-modules to 1.2.3.4"],
+            expected_data_count=2,
+            new_release=True,
+            require_important_update=True,
+        )
+
+    async def test_update_no_main_source_updated(self):
+        """With two sources, while one source is updated it is not the main one,
+        so no manifest update should be made."""
+        filename = "importantsource.com.virustotal.Uploader.yml"
+        contents = """
+id: importantsource.com.virustotal.Uploader
+modules:
+  - name: extra-cmake-modules
+    sources:
+      - type: git
+        url: https://github.com/KDE/extra-cmake-modules
+        tag: 0.0.0.0
+        commit: 0000000000000000000000000000000000000000
+        x-checker-data:
+          type: git
+          tag-pattern: ^v(\d[\d.]+\d)$
+  - name: vt-py
+    sources:
+      # Current is valid, no updates
+      - type: git
+        url: https://github.com/VirusTotal/vt-py.git
+        tag: 1.2.3.4
+        commit: 0000000000000000000000000000000000000000
+        x-checker-data:
+          type: git
+          tag-pattern: ^(0.5.4)$
+          sort-tags: false
+          is-main-source: true
+          # since this is marked as the only important/main source,
+          # but isn't getting updated, manifest should not be updated
+""".lstrip()
+        expected_new_contents = f"""
+id: importantsource.com.virustotal.Uploader
+modules:
+  - name: extra-cmake-modules
+    sources:
+      - type: git
+        url: https://github.com/KDE/extra-cmake-modules
+        tag: 0.0.0.0
+        commit: 0000000000000000000000000000000000000000
+        x-checker-data:
+          type: git
+          tag-pattern: ^v(\d[\d.]+\d)$
+  - name: vt-py
+    sources:
+      # Current is valid, no updates
+      - type: git
+        url: https://github.com/VirusTotal/vt-py.git
+        tag: 1.2.3.4
+        commit: 0000000000000000000000000000000000000000
+        x-checker-data:
+          type: git
+          tag-pattern: ^(0.5.4)$
+          sort-tags: false
+          is-main-source: true
+          # since this is marked as the only important/main source,
+          # but isn't getting updated, manifest should not be updated
+""".lstrip()
+        await self._test_update(
+            filename=filename,
+            contents=contents,
+            expected_new_contents=expected_new_contents,
+            expected_updates=[],
+            expected_data_count=2,
+            new_release=False,
+            require_important_update=True,
+        )
+
+    async def test_update_one_main_source_updated(self):
+        """With two sources, one of them being the main source and updated,
+        so a manifest update should be made."""
+        filename = "importantsource.com.virustotal.Uploader.yml"
+        contents = f"""
+id: importantsource.com.virustotal.Uploader
+modules:
+  - name: extra-cmake-modules
+    sources:
+      - type: git
+        url: https://github.com/KDE/extra-cmake-modules
+        tag: 0.0.0.0
+        commit: 0000000000000000000000000000000000000000
+        x-checker-data:
+          type: git
+          tag-pattern: ^(v5\.90\.0)$ # to ensure we only get this version
+          is-main-source: true
+          # since this is marked as the only main source,
+          # and is actually getting updated, manifest should be updated
+  - name: vt-py
+    sources:
+      # Current is valid, no updates
+      - type: git
+        url: https://github.com/VirusTotal/vt-py.git
+        tag: {GitUpdateEverythingChecker.TAG}
+        commit: {GitUpdateEverythingChecker.COMMIT}
+        x-checker-data:
+          type: git
+          tag-pattern: ^(0.5.4)$
+          sort-tags: false
+""".lstrip()
+        expected_new_contents = f"""
+id: importantsource.com.virustotal.Uploader
+modules:
+  - name: extra-cmake-modules
+    sources:
+      - type: git
+        url: https://github.com/KDE/extra-cmake-modules
+        tag: {GitUpdateEverythingChecker.TAG}
+        commit: {GitUpdateEverythingChecker.COMMIT}
+        x-checker-data:
+          type: git
+          tag-pattern: ^(v5\.90\.0)$ # to ensure we only get this version
+          is-main-source: true
+          # since this is marked as the only main source,
+          # and is actually getting updated, manifest should be updated
+  - name: vt-py
+    sources:
+      # Current is valid, no updates
+      - type: git
+        url: https://github.com/VirusTotal/vt-py.git
+        tag: {GitUpdateEverythingChecker.TAG}
+        commit: {GitUpdateEverythingChecker.COMMIT}
+        x-checker-data:
+          type: git
+          tag-pattern: ^(0.5.4)$
+          sort-tags: false
+""".lstrip()
+        await self._test_update(
+            filename=filename,
+            contents=contents,
+            expected_new_contents=expected_new_contents,
+            expected_updates=["Update extra-cmake-modules to 1.2.3.4"],
+            expected_data_count=2,
+            new_release=True,
+            require_important_update=True,
+        )
+
+    async def test_require_important_source_disabled_no_important_source_updated(self):
+        """With two sources, one being important, but with require_important_source=false, so normal behaviour should occur.
+        Should disregard the fact that there is a singular important source not being updated"""
+        filename = "importantsource.com.virustotal.Uploader.yml"
+        contents = """
+id: importantsource.com.virustotal.Uploader
+modules:
+  - name: extra-cmake-modules
+    sources:
+      - type: git
+        url: https://github.com/KDE/extra-cmake-modules
+        tag: 0.0.0.0
+        commit: 0000000000000000000000000000000000000000
+        x-checker-data:
+          type: git
+          tag-pattern: ^v(\d[\d.]+\d)$
+  - name: vt-py
+    sources:
+      # Current is valid, no updates
+      - type: git
+        url: https://github.com/VirusTotal/vt-py.git
+        tag: 0.0.0.0
+        commit: 0000000000000000000000000000000000000000
+        x-checker-data:
+          type: git
+          tag-pattern: ^(0.5.4)$
+          sort-tags: false
+          is-important: true
+          # manifest should still be updated since the require_important source is disabled
+""".lstrip()
+        expected_new_contents = f"""
+id: importantsource.com.virustotal.Uploader
+modules:
+  - name: extra-cmake-modules
+    sources:
+      - type: git
+        url: https://github.com/KDE/extra-cmake-modules
+        tag: {GitUpdateEverythingChecker.TAG}
+        commit: {GitUpdateEverythingChecker.COMMIT}
+        x-checker-data:
+          type: git
+          tag-pattern: ^v(\d[\d.]+\d)$
+  - name: vt-py
+    sources:
+      # Current is valid, no updates
+      - type: git
+        url: https://github.com/VirusTotal/vt-py.git
+        tag: {GitUpdateEverythingChecker.TAG}
+        commit: {GitUpdateEverythingChecker.COMMIT}
+        x-checker-data:
+          type: git
+          tag-pattern: ^(0.5.4)$
+          sort-tags: false
+          is-important: true
+          # manifest should still be updated since the require_important source is disabled
+""".lstrip()
+        await self._test_update(
+            filename=filename,
+            contents=contents,
+            expected_new_contents=expected_new_contents,
+            expected_updates=[
+                "Update extra-cmake-modules to 1.2.3.4",
+                "Update vt-py.git to 1.2.3.4",
+            ],
+            expected_data_count=2,
+            new_release=True,
+            require_important_update=False,
+        )
+
+    async def test_main_source_not_important(self):
+        """Normally the main source is considered important, however this can be overridden by setting is-important: false"""
+        filename = "importantsource.com.virustotal.Uploader.yml"
+        contents = f"""
+id: importantsource.com.virustotal.Uploader
+modules:
+  - name: vt-py
+    sources:
+      # Current is valid, no updates
+      - type: git
+        url: https://github.com/VirusTotal/vt-py.git
+        tag: {GitUpdateEverythingChecker.TAG}
+        commit: {GitUpdateEverythingChecker.COMMIT}
+        x-checker-data:
+          type: git
+          tag-pattern: ^(0.5.4)$
+          sort-tags: false
+          is-important: true
+          # this is marked as important and not being updated
+  - name: extra-cmake-modules
+    sources:
+      - type: git
+        url: https://github.com/KDE/extra-cmake-modules
+        tag: 0.0.0.0
+        commit: 0000000000000000000000000000000000000000
+        x-checker-data:
+          type: git
+          tag-pattern: ^(v5\.90\.0)$ # to ensure we only get this version
+          is-main-source: true
+          is-important: false
+          # since this is marked as the main source but is not important, it should not be updated
+""".lstrip()
+        expected_new_contents = f"""
+id: importantsource.com.virustotal.Uploader
+modules:
+  - name: vt-py
+    sources:
+      # Current is valid, no updates
+      - type: git
+        url: https://github.com/VirusTotal/vt-py.git
+        tag: {GitUpdateEverythingChecker.TAG}
+        commit: {GitUpdateEverythingChecker.COMMIT}
+        x-checker-data:
+          type: git
+          tag-pattern: ^(0.5.4)$
+          sort-tags: false
+          is-important: true
+          # this is marked as important and not being updated
+  - name: extra-cmake-modules
+    sources:
+      - type: git
+        url: https://github.com/KDE/extra-cmake-modules
+        tag: 0.0.0.0
+        commit: 0000000000000000000000000000000000000000
+        x-checker-data:
+          type: git
+          tag-pattern: ^(v5\.90\.0)$ # to ensure we only get this version
+          is-main-source: true
+          is-important: false
+          # since this is marked as the main source but is not important, it should not be updated
+""".lstrip()
+        await self._test_update(
+            filename=filename,
+            contents=contents,
+            expected_new_contents=expected_new_contents,
+            expected_updates=[],
+            expected_data_count=2,
+            new_release=False,
+            require_important_update=True,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes https://github.com/flathub/flatpak-external-data-checker/issues/249

I opted to add an optional property to mark sources as "important", `is-important: true`. If "important" sources are present in external data, only update the manifest if at least 1 important source received an update. This basically lets apps choose when they want PRs to open, e.g. many apps may only want a PR when at least their primary upstream app source is updated. 

Manifests without important sources will not be affected by this change. f-e-d-c will continue making manifest updates as before for all modules. In other words, this does not change any existing behaviour.

There are some (I think comprehensive) tests for this feature in `test_checker.py`.

I also tested with an actual GitHub repo (forked EasyEffects which happens to have convenient action to use):

> [When is-critical-source is set for EasyEffects itself, but only libsigc++ has an update available](https://github.com/vchernin/com.github.wwmm.easyeffects/runs/5294315473?check_suite_focus=true)

Doesn't make a PR/manifest update as shown by the logs as expected

> [When is-critical-source is set for both for EasyEffects and libsigc++, and libsigc++ has an update available](https://github.com/vchernin/com.github.wwmm.easyeffects/runs/5294368744?check_suite_focus=true)

Makes [PR as expected](https://github.com/vchernin/com.github.wwmm.easyeffects/pull/5)