### PR TITLE
 Allow setting multiple data states

### DIFF
--- a/src/checkers/gitchecker.py
+++ b/src/checkers/gitchecker.py
@@ -159,7 +159,7 @@ class GitChecker(Checker):
         try:
             remote_version = await external_data.current_version.fetch_remote()
         except CheckerFetchError:
-            external_data.state = ExternalGitRepo.State.BROKEN
+            external_data.state |= external_data.State.BROKEN
             raise
 
         external_data.set_new_version(remote_version, is_update=False)

--- a/src/checkers/urlchecker.py
+++ b/src/checkers/urlchecker.py
@@ -119,7 +119,7 @@ class URLChecker(Checker):
                 )
         except NETWORK_ERRORS as err:
             if not is_rotating:
-                external_data.state = ExternalData.State.BROKEN
+                external_data.state |= external_data.State.BROKEN
             raise CheckerFetchError from err
 
         if is_rotating and not version_string:

--- a/src/lib/externaldata.py
+++ b/src/lib/externaldata.py
@@ -20,7 +20,7 @@
 from __future__ import annotations
 
 import abc
-from enum import Enum
+from enum import Enum, IntFlag
 import datetime
 import typing as t
 import dataclasses
@@ -69,7 +69,7 @@ class BuilderSource(abc.ABC):
         "required": ["type"],
     }
 
-    class Type(Enum):
+    class Type(str, Enum):
         EXTRA_DATA = "extra-data"
         FILE = "file"
         ARCHIVE = "archive"
@@ -78,10 +78,14 @@ class BuilderSource(abc.ABC):
         def __str__(self):
             return self.value
 
-    class State(Enum):
+    class State(IntFlag):
         UNKNOWN = 0
+        # Current version state
         VALID = 1 << 1  # URL is reachable
         BROKEN = 1 << 2  # URL couldn't be reached
+        # New version state
+        LATEST = 1 << 3
+        OUTDATED = 1 << 4
 
     type: t.ClassVar[Type]
     state: State
@@ -172,17 +176,19 @@ class ExternalBase(BuilderSource):
         if self.current_version.matches(new_version):
             if is_update:
                 log.debug("Source %s: no update found", self.filename)
+                self.state |= self.State.LATEST
             else:
                 log.debug("Source %s: no remote data change", self.filename)
-            self.state = self.State.VALID
+            self.state |= self.State.VALID
         else:
             if is_update:
                 log.info(
                     "Source %s: got new version %s", self.filename, new_version.version
                 )
+                self.state |= self.State.OUTDATED
             else:
                 log.warning("Source %s: remote data changed", self.filename)
-                self.state = self.State.BROKEN
+                self.state |= self.State.BROKEN
             self.new_version = new_version
 
     def update(self):

--- a/src/main.py
+++ b/src/main.py
@@ -62,9 +62,7 @@ def indir(path):
 def print_outdated_external_data(manifest_checker: manifest.ManifestChecker):
     ext_data = manifest_checker.get_outdated_external_data()
     for data in ext_data:
-        state_txt = (
-            data.state.name if data.state == data.State.BROKEN else "CHANGE SOON"
-        )
+        state_txt = data.state.name or str(data.state)
         message_tmpl = ""
         message_args = {}
         if data.new_version:
@@ -100,7 +98,7 @@ def print_outdated_external_data(manifest_checker: manifest.ManifestChecker):
                     **data.new_version._asdict(),
                     **data.new_version.checksum._asdict(),
                 }
-        elif data.state == data.State.BROKEN:
+        elif data.State.BROKEN in data.state:
             message_tmpl = (
                 # fmt: off
                 "{data_state}: {data_name}\n"
@@ -265,8 +263,8 @@ def open_pr(
         and manifest_checker
         # …and at least one source is broken and has an update
         and any(
-            data.type == ExternalData.Type.EXTRA_DATA
-            and data.state == ExternalData.State.BROKEN
+            data.type == data.Type.EXTRA_DATA
+            and data.State.BROKEN in data.state
             and data.new_version
             for data in manifest_checker.get_outdated_external_data()
         )

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -297,11 +297,11 @@ class ManifestChecker:
                 # but applying checkers in sequence should be carefully tested.
                 # This is a safety switch: leave the data alone on error.
                 return data
-            if data.state != ExternalBase.State.UNKNOWN:
+            if data.state != data.State.UNKNOWN:
                 log.debug(
-                    "Source %s: got new state %s from %s, skipping remaining checkers",
+                    "Source %s: got new %s from %s, skipping remaining checkers",
                     data,
-                    data.state.name,
+                    data.state,
                     checker.__class__.__name__,
                 )
                 break
@@ -341,7 +341,7 @@ class ManifestChecker:
         ) as http_session:
             check_tasks = []
             for data in external_data:
-                if data.state != ExternalBase.State.UNKNOWN:
+                if data.state != data.State.UNKNOWN:
                     continue
                 check_tasks.append(self._check_data(counter, http_session, data))
 
@@ -382,7 +382,7 @@ class ManifestChecker:
         return [
             data
             for data in self.get_external_data()
-            if data.state == ExternalBase.State.BROKEN or data.new_version
+            if data.State.BROKEN in data.state or data.new_version
         ]
 
     def _update_manifest(self, path, datas, changes):

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -75,7 +75,7 @@ class UpdateEverythingChecker(DummyChecker):
     TIMESTAMP = dt.datetime(2019, 8, 28, 0, 0, 0)
 
     async def check(self, external_data):
-        external_data.state = ExternalData.State.BROKEN
+        external_data.state |= external_data.State.BROKEN
         external_data.new_version = external_data.current_version._replace(
             size=self.SIZE,
             checksum=MultiDigest(sha256=self.CHECKSUM),

--- a/tests/test_gitchecker.py
+++ b/tests/test_gitchecker.py
@@ -61,19 +61,19 @@ class TestGitChecker(unittest.IsolatedAsyncioTestCase):
                 )
                 self.assertFalse(data.current_version.matches(data.new_version))
             elif data.filename == "qt-virustotal-uploader.git":
-                self.assertEqual(data.state, data.State.VALID)
+                self.assertIn(data.State.VALID, data.state)
                 self.assertIsNone(data.new_version)
             elif data.filename == "protobuf-c.git":
                 self.assertEqual(data.state, data.State.UNKNOWN)
                 self.assertIsNone(data.new_version)
             elif data.filename == "yara.git":
-                self.assertEqual(data.state, data.State.BROKEN)
+                self.assertIn(data.State.BROKEN, data.state)
                 self.assertIsNone(data.new_version)
             elif data.filename == "yara-python.git":
                 self.assertEqual(data.state, data.State.UNKNOWN)
                 self.assertIsNone(data.new_version)
             elif data.filename == "vt-py.git":
-                self.assertEqual(data.state, data.State.VALID)
+                self.assertIn(data.State.VALID, data.state)
                 self.assertIsNone(data.new_version)
             elif data.filename == "extra-cmake-modules.git":
                 self.assertIsNotNone(data.new_version)


### PR DESCRIPTION
Keep multiple state flags per source, which indicate simultaneously whether the source current version is valid (downloadable) or broken, _and_ whether it is the latest version or there is an update available.
This will allow us to validate the current version even if a checker previously didn't find a new version (e.g. apply URLChecker after AnityaChecker if the later didn't get an update).

This is a prerequisite for resolving #257.