### PR TITLE
checkers: Skip download if URL unchanged

### DIFF
--- a/src/lib/checkers.py
+++ b/src/lib/checkers.py
@@ -151,7 +151,10 @@ class Checker:
         assert latest_version is not None
         assert latest_url is not None
 
-        if latest_url == external_data.current_version.url:
+        if (
+            latest_url == external_data.current_version.url
+            and external_data.type != external_data.Type.EXTRA_DATA
+        ):
             external_data.state |= external_data.State.LATEST
             return
 

--- a/src/lib/checkers.py
+++ b/src/lib/checkers.py
@@ -151,6 +151,10 @@ class Checker:
         assert latest_version is not None
         assert latest_url is not None
 
+        if latest_url == external_data.current_version.url:
+            external_data.state |= external_data.State.LATEST
+            return
+
         if external_data.type == ExternalData.Type.ARCHIVE:
             wrong_content_types = WRONG_CONTENT_TYPES_ARCHIVE
         else:


### PR DESCRIPTION
If the new version we've got has the same URL as the current one, don't download it again. This will drastically reduce check times.

Although this means we won't re-validate `extra-data` sources that use checkers that don't always get integrity (e.g. HTMLChecker). There are two ways around this:
- either make an exception for `extra-data` sources in `Checker._update_version()` and still download them
- or allow applying checkers in sequence, so that e.g. URLChecker can still validate `extra-data` after HTMLChecker didn't get a new version

The former is much easier, the later is overall cleaner and more universal. I'd like @wjt opinion on which approach would be better.
Marking as draft until either approach is taken and implemented.

Closes #257