### PR TITLE
checkers: ability to replace timestamp

### DIFF
--- a/src/checkers/jsonchecker.py
+++ b/src/checkers/jsonchecker.py
@@ -132,13 +132,20 @@ class JSONChecker(Checker):
         checker_data = external_data.checker_data
         results = await self._query_sequence(
             json_data,
-            self._read_q_seq(checker_data, ["tag", "commit", "version", "url"]),
+            self._read_q_seq(
+                checker_data, ["tag", "commit", "version", "url", "timestamp"]
+            ),
         )
         latest_version = results["version"]
         latest_url = results["url"]
+        latest_timestamp = parse_timestamp(results.get("timestamp"))
 
         await self._update_version(
-            external_data, latest_version, latest_url, follow_redirects=False
+            external_data,
+            latest_version,
+            latest_url,
+            follow_redirects=False,
+            timestamp=latest_timestamp,
         )
 
     async def _check_git(self, json_data: bytes, external_data: ExternalGitRepo):

--- a/src/lib/checkers.py
+++ b/src/lib/checkers.py
@@ -6,6 +6,7 @@ import typing as t
 import aiohttp
 from yarl import URL
 import jsonschema
+import datetime
 
 from . import (
     utils,
@@ -147,6 +148,7 @@ class Checker:
         latest_version: str,
         latest_url: str,
         follow_redirects: bool = False,
+        timestamp: t.Optional[datetime.datetime] = None,
     ):
         assert latest_version is not None
         assert latest_url is not None
@@ -180,4 +182,6 @@ class Checker:
         new_version = new_version._replace(
             version=latest_version  # pylint: disable=no-member
         )
+        if timestamp is not None:
+            new_version = new_version._replace(timestamp=timestamp)
         external_data.set_new_version(new_version)

--- a/tests/io.github.stedolan.jq.yml
+++ b/tests/io.github.stedolan.jq.yml
@@ -10,6 +10,17 @@ modules:
           url: https://api.github.com/repos/stedolan/jq/releases/latest
           version-query: '.tag_name | sub("^jq-"; "")'
           url-query: '.assets[] | select(.name=="jq-" + $version + ".tar.gz") | .browser_download_url'
+
+      - type: archive
+        dest-filename: jq-1.4.tarball.tar.gz
+        url: https://api.github.com/repos/stedolan/jq/tarball/jq-1.4
+        sha256: "0000000000000000000000000000000000000000000000000000000000000000"
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/stedolan/jq/releases/13660432
+          version-query: '.tag_name | sub("^jq-"; "")'
+          url-query: '.tarball_url'
+          timestamp-query: '.published_at'
     modules:
 
       - name: oniguruma

--- a/tests/test_jsonchecker.py
+++ b/tests/test_jsonchecker.py
@@ -18,7 +18,7 @@ class TestJSONChecker(unittest.IsolatedAsyncioTestCase):
         checker = ManifestChecker(TEST_MANIFEST)
         ext_data = await checker.check()
 
-        self.assertEqual(len(ext_data), 7)
+        self.assertEqual(len(ext_data), 8)
         for data in ext_data:
             self.assertIsNotNone(data)
             if data.filename == "jq-1.4.tar.gz":
@@ -37,6 +37,11 @@ class TestJSONChecker(unittest.IsolatedAsyncioTestCase):
                     MultiDigest(
                         sha256="0000000000000000000000000000000000000000000000000000000000000000"
                     ),
+                )
+            elif data.filename == "jq-1.4.tarball.tar.gz":
+                self.assertEqual(
+                    data.new_version.timestamp,
+                    datetime.datetime.fromisoformat("2018-11-02T01:54:23+00:00"),
                 )
             elif data.filename == "oniguruma.git":
                 self.assertIsInstance(data.new_version, ExternalGitRef)


### PR DESCRIPTION
add 'timestamp' parameter to _update_version, for jsonchecker using timestamp from json rather than using the one from url response date.  

Fix for tarballs from GitHub.  

Example:
```yaml
    sources:
      - type: archive
        url: https://github.com/laurent22/joplin/archive/v2.8.4.tar.gz
        sha256: d039577ecc1e7589e7432f45d4e12308d16b5df0c1b0cc928bc451d8136761d4
        x-checker-data:
          type: json
          url: https://api.github.com/repos/laurent22/joplin/releases
          version-query: .[0] | .tag_name | sub("^v"; "")
          url-query: '"https://github.com/laurent22/joplin/archive/v" + $version +
            ".tar.gz"'
          timestamp-query: .[0] | .published_at
```