### PR TITLE
Implement parent-child relations between sources

### DIFF
--- a/src/lib/externaldata.py
+++ b/src/lib/externaldata.py
@@ -124,6 +124,12 @@ class BuilderSource(abc.ABC):
     def from_source_impl(cls: t.Type[_BS], source_path: str, source: t.Dict) -> _BS:
         raise NotImplementedError
 
+    def __str__(self):
+        return f"{self.type.value} {self.filename}"
+
+    def __repr__(self):
+        return f"<{type(self).__name__} {self}>"
+
 
 @dataclasses.dataclass(frozen=True)
 class ExternalState(abc.ABC):
@@ -195,12 +201,6 @@ class ExternalBase(BuilderSource):
         """If self.new_version is not None, writes back the necessary changes to the
         original element from the manifest."""
         raise NotImplementedError
-
-    def __str__(self):
-        return f"{self.type.value} {self.filename}"
-
-    def __repr__(self):
-        return f"<{type(self).__name__} {self}>"
 
 
 @dataclasses.dataclass(frozen=True)

--- a/src/lib/externaldata.py
+++ b/src/lib/externaldata.py
@@ -168,7 +168,10 @@ class BuilderSource(abc.ABC):
         raise NotImplementedError
 
     def __str__(self):
-        return f"{self.type.value} {self.filename}"
+        name = self.filename
+        if self.module:
+            name = f"{self.module.name}/{name}"
+        return f"{self.type.value} {name}"
 
     def __repr__(self):
         return f"<{type(self).__name__} {self}>"

--- a/src/lib/externaldata.py
+++ b/src/lib/externaldata.py
@@ -51,6 +51,7 @@ CHECKER_DATA_SCHEMA_COMMON = {
             "items": {"type": "string"},
         },
         "source-id": {"type": "string"},
+        "parent-id": {"type": "string"},
     },
     "required": ["type"],
 }
@@ -123,6 +124,7 @@ class BuilderSource(abc.ABC):
     source_path: str
     checker_data: t.Dict[str, t.Any]
     module: t.Optional[BuilderModule]
+    parent: t.Optional[BuilderSource] = dataclasses.field(init=False, default=None)
 
     def __post_init__(self):
         if self.module:

--- a/src/lib/externaldata.py
+++ b/src/lib/externaldata.py
@@ -50,6 +50,7 @@ CHECKER_DATA_SCHEMA_COMMON = {
             "type": "array",
             "items": {"type": "string"},
         },
+        "source-id": {"type": "string"},
     },
     "required": ["type"],
 }
@@ -166,6 +167,15 @@ class BuilderSource(abc.ABC):
         module: t.Optional[BuilderModule] = None,
     ) -> _BS:
         raise NotImplementedError
+
+    @property
+    def ident(self) -> str:
+        if "source-id" in self.checker_data:
+            return self.checker_data["source-id"]
+        if self.module:
+            index = [s for s in self.module.sources if s.type == self.type].index(self)
+            return f"{self.module.name}-{self.type.value}-{index}"
+        raise SourceLoadError("Can't get source id")
 
     def __str__(self):
         name = self.filename

--- a/src/lib/externaldata.py
+++ b/src/lib/externaldata.py
@@ -25,6 +25,7 @@ import datetime
 import typing as t
 import dataclasses
 import logging
+import asyncio
 
 from yarl import URL
 import jsonschema
@@ -125,6 +126,9 @@ class BuilderSource(abc.ABC):
     checker_data: t.Dict[str, t.Any]
     module: t.Optional[BuilderModule]
     parent: t.Optional[BuilderSource] = dataclasses.field(init=False, default=None)
+    # fmt: off
+    checked: asyncio.Event = dataclasses.field(init=False, default_factory=asyncio.Event)
+    # fmt: on
 
     def __post_init__(self):
         if self.module:

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,0 +1,164 @@
+import unittest
+import json
+import os
+import random
+import string
+import tempfile
+
+from src.manifest import ManifestChecker
+
+
+TEST_MANIFEST_DATA = {
+    "id": "fedc.test.Loader",
+    "modules": [
+        {
+            "name": "first",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "http://example.com/first-repo.git",
+                },
+                {
+                    "type": "file",
+                    "url": "http://example.com/first-one.txt",
+                    "sha256": "x",
+                },
+                {
+                    "type": "file",
+                    "url": "http://example.com/first-two.txt",
+                    "sha256": "x",
+                },
+            ],
+        },
+        {
+            "name": "second",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "http://example.com/second-repo.git",
+                },
+            ],
+            "modules": [
+                {
+                    "name": "first-child",
+                    "sources": [
+                        {
+                            "type": "git",
+                            "url": "http://example.com/first-child-repo.git",
+                        },
+                        {
+                            "type": "file",
+                            "url": "http://example.com/first-child.txt",
+                            "sha256": "x",
+                        },
+                    ],
+                    "modules": [
+                        {
+                            "name": "first-grandchild",
+                            "sources": [
+                                {
+                                    "type": "archive",
+                                    "url": "http://example.com/first-grandchild.tar",
+                                    "sha256": "x",
+                                },
+                            ],
+                        },
+                    ],
+                },
+                {
+                    "name": "second-child",
+                    "sources": [
+                        {
+                            "type": "file",
+                            "url": "http://example.com/second-child.txt",
+                            "sha256": "x",
+                        },
+                        {
+                            "type": "patch",
+                            "path": "second-child.patch",
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            "name": "third",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://example.com/third.tar",
+                    "sha256": "x",
+                },
+            ],
+        },
+    ],
+}
+
+# pylint: disable=protected-access
+class TestManifestLoader(unittest.IsolatedAsyncioTestCase):
+    test_dir: tempfile.TemporaryDirectory
+
+    def setUp(self):
+        self.test_dir = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        self.test_dir.cleanup()
+
+    def _load_manifest(self, manifest_data):
+        rand = "".join(random.sample(string.ascii_letters + string.digits, 10))
+        mf_path = os.path.join(self.test_dir.name, f"{rand}.json")
+
+        with open(mf_path, "w") as mf:
+            json.dump(manifest_data, mf)
+
+        return ManifestChecker(mf_path)
+
+    def test_load(self):
+        manifest = self._load_manifest(TEST_MANIFEST_DATA)
+        self.assertEqual(manifest.kind, manifest.Kind.APP)
+        modules = sum(manifest._modules.values(), [])
+        self.assertEqual(len(modules), 6)
+
+        # fmt: off
+        self.assertEqual(modules[0].name, "first")
+        self.assertIsNone(modules[0].parent)
+        self.assertEqual(
+            [s.filename for s in modules[0].sources],
+            ["first-repo.git", "first-one.txt", "first-two.txt"],
+        )
+
+        self.assertEqual(modules[1].name, "second")
+        self.assertIsNone(modules[1].parent)
+        self.assertEqual(
+            [s.filename for s in modules[1].sources],
+            ["second-repo.git"],
+        )
+
+        self.assertEqual(modules[2].name, "first-child")
+        self.assertIs(modules[2].parent, modules[1])
+        self.assertEqual(
+            [s.filename for s in modules[2].sources],
+            ["first-child-repo.git", "first-child.txt"],
+        )
+
+        self.assertEqual(modules[3].name, "first-grandchild")
+        self.assertIs(modules[3].parent, modules[2])
+        self.assertEqual(
+            [s.filename for s in modules[3].sources],
+            ["first-grandchild.tar"],
+        )
+
+        self.assertEqual(modules[4].name, "second-child")
+        self.assertIs(modules[4].parent, modules[1])
+        self.assertEqual(
+            [s.filename for s in modules[4].sources],
+            ["second-child.txt"],
+        )
+
+        self.assertEqual(modules[5].name, "third")
+        self.assertIsNone(modules[5].parent)
+        self.assertEqual(
+            [s.filename for s in modules[5].sources],
+            ["third.tar"],
+        )
+        # fmt: on

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -22,6 +22,10 @@ TEST_MANIFEST_DATA = {
                     "type": "file",
                     "url": "http://example.com/first-one.txt",
                     "sha256": "x",
+                    "x-checker-data": {
+                        "type": "dummy",
+                        "source-id": "my-custom-id",
+                    },
                 },
                 {
                     "type": "file",
@@ -126,12 +130,20 @@ class TestManifestLoader(unittest.IsolatedAsyncioTestCase):
             [s.filename for s in modules[0].sources],
             ["first-repo.git", "first-one.txt", "first-two.txt"],
         )
+        self.assertEqual(
+            [s.ident for s in modules[0].sources],
+            ["first-git-0", "my-custom-id", "first-file-1"],
+        )
 
         self.assertEqual(modules[1].name, "second")
         self.assertIsNone(modules[1].parent)
         self.assertEqual(
             [s.filename for s in modules[1].sources],
             ["second-repo.git"],
+        )
+        self.assertEqual(
+            [s.ident for s in modules[1].sources],
+            ["second-git-0"],
         )
 
         self.assertEqual(modules[2].name, "first-child")
@@ -140,12 +152,20 @@ class TestManifestLoader(unittest.IsolatedAsyncioTestCase):
             [s.filename for s in modules[2].sources],
             ["first-child-repo.git", "first-child.txt"],
         )
+        self.assertEqual(
+            [s.ident for s in modules[2].sources],
+            ["first-child-git-0", "first-child-file-0"],
+        )
 
         self.assertEqual(modules[3].name, "first-grandchild")
         self.assertIs(modules[3].parent, modules[2])
         self.assertEqual(
             [s.filename for s in modules[3].sources],
             ["first-grandchild.tar"],
+        )
+        self.assertEqual(
+            [s.ident for s in modules[3].sources],
+            ["first-grandchild-archive-0"],
         )
 
         self.assertEqual(modules[4].name, "second-child")
@@ -154,11 +174,19 @@ class TestManifestLoader(unittest.IsolatedAsyncioTestCase):
             [s.filename for s in modules[4].sources],
             ["second-child.txt"],
         )
+        self.assertEqual(
+            [s.ident for s in modules[4].sources],
+            ["second-child-file-0"],
+        )
 
         self.assertEqual(modules[5].name, "third")
         self.assertIsNone(modules[5].parent)
         self.assertEqual(
             [s.filename for s in modules[5].sources],
             ["third.tar"],
+        )
+        self.assertEqual(
+            [s.ident for s in modules[5].sources],
+            ["third-archive-0"],
         )
         # fmt: on


### PR DESCRIPTION
This adds foundation for resolving #144

Allow the user to specify `parent-id` property in `x-checker-data`, indicating that the current source will use check results from the source with specified id.

In order to establish inter-source relations, we need some kind of source identifiers that are not changed with updates. For that, we can either use a user-provided id, or construct id from the module name and the source position number. For that, we collect flatpak-builder modules.

In scope of this PR, inter-source relations only affect checking order (child check starts only after its parent was checked). But from now on, checkers can take parent source data into account (e.g. access `external_data.parent.new_version`) and, depending on it, pick different upstream url or pre-populate git tag to match parent, for example. Actual parent data usage is to be implemented on per-checker basis.