### PR TITLE
pypichecker: Implement pre-release filtering

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get update && \
       python3-jsonschema \
       python3-editorconfig \
       python3-lxml \
+      python3-packaging \
       squashfs-tools \
       ssh-client \
       jq \

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ semver
 jsonschema
 editorconfig
 lxml
+packaging

--- a/tests/com.valvesoftware.Steam.yml
+++ b/tests/com.valvesoftware.Steam.yml
@@ -38,3 +38,21 @@ modules:
           type: pypi
           name: Pillow
           packagetype: bdist_wheel
+
+      - type: file
+        url: http://example.com/allow-prerelease
+        sha256: x
+        x-checker-data:
+          type: pypi
+          name: borgbackup
+          versions: { "<": "1.2" }
+          stable-only: false
+
+      - type: file
+        url: http://example.com/disallow-prerelease
+        sha256: x
+        x-checker-data:
+          type: pypi
+          name: borgbackup
+          versions: { "<": "1.2" }
+          stable-only: true


### PR DESCRIPTION
Use packaging.version module to parse package versions and filter-out pre-releases if `stable-only` was requested.

Fixes #176 