### PR TITLE
Refactor version sorting/filtering helper

### DIFF
--- a/src/checkers/gitchecker.py
+++ b/src/checkers/gitchecker.py
@@ -6,7 +6,7 @@ import semver
 
 from ..lib import OPERATORS_SCHEMA
 from ..lib.externaldata import ExternalBase, ExternalGitRepo, ExternalGitRef
-from ..lib.utils import git_ls_remote, filter_versioned_items, TrialVersion
+from ..lib.utils import git_ls_remote, filter_versioned_items, FallbackVersion
 from ..lib.errors import CheckerQueryError, CheckerFetchError
 from ..lib.checkers import Checker
 
@@ -24,7 +24,7 @@ class TagWithVersion(t.NamedTuple):
 
     @classmethod
     def parse_version(cls, version: str):
-        return TrialVersion(version)
+        return FallbackVersion(version)
 
     @property
     def parsed_version(self):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -34,6 +34,8 @@ from src.lib.utils import (
     parse_github_url,
     strip_query,
     filter_versions,
+    filter_versioned_items,
+    FallbackVersion,
     _extract_timestamp,
     get_extra_data_info_from_url,
     Command,
@@ -175,10 +177,10 @@ class TestVersionFilter(unittest.TestCase):
 
     def test_objects(self):
         self.assertEqual(
-            filter_versions(
+            filter_versioned_items(
                 [("c", "1.1"), ("a", "1.3"), ("b", "1.2"), ("d", "1.0")],
-                [("!=", "1.2")],
-                to_string=lambda o: o[1],
+                [("!=", FallbackVersion("1.2"))],
+                to_version=lambda o: FallbackVersion(o[1]),
                 sort=True,
             ),
             [("d", "1.0"), ("c", "1.1"), ("a", "1.3")],


### PR DESCRIPTION
The `filter_version` function has become complex yet not very flexible.
Split it up into two helpers: for handling arbitrary versioned objects (`filter_versioned_items`) and for handling plain strings (`filter_versions`).
Comparison logic moved to the `FallbackVersion` class that somehow combines `StrictVersion` and `LooseVersion`, trying to use them both, in order.
This way we can let checkers choose arbitrary version class (instead of the default `FallbackVersion`) for filtering and/or sorting versioned objects.