### PR TITLE
JSONChecker: Support YAML URLs and access to parent source properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,14 @@ for git type sources, specify tag query and, optionaly, commit and version queri
 
 See the [jq manual](https://stedolan.github.io/jq/manual/) for complete information about writing queries.
 
+#### Inheriting parent source check results
+
+If a parent source is specified, its check results will be accessible in the `$parent` variable.
+The `$parent` object has `current` and `new` properties with objects representing current and new
+parent source data, respectively. The later can be `null` if parent check didn't get a new version.
+JSON schema for these objects can be found [here](data/source-state.schema.json).
+
+
 ### Debian repo checker
 
 For the **DebianRepoChecker**, which deals only with deb packages, it

--- a/data/source-state.schema.json
+++ b/data/source-state.schema.json
@@ -1,0 +1,41 @@
+{
+  "$defs": {
+    "source-state": {
+      "file": {
+        "type": "object",
+        "properties": {
+          "url": { "type": "string" },
+          "checksum": {
+            "type": "object",
+            "properties": {
+              "md5": { "type": "string" },
+              "sha1": { "type": "string" },
+              "sha256": { "type": "string" },
+              "sha512": { "type": "string" }
+            }
+          },
+          "version": { "type": "string" },
+          "timestamp": { "type": "string" }
+        },
+        "required": [ "url", "checksum" ]
+      },
+      "git": {
+        "type": "object",
+        "properties": {
+          "url": { "type": "string" },
+          "commit": { "type": "string" },
+          "tag": { "type": "string" },
+          "branch": { "type": "string" },
+          "version": { "type": "string" },
+          "timestamp": { "type": "string" }
+        },
+        "required": [ "url" ]
+      }
+    }
+  },
+  "type": "object",
+  "anyOf": [
+    { "$ref": "#/$defs/source-state/file" },
+    { "$ref": "#/$defs/source-state/git" }
+  ]
+}

--- a/src/checkers/jsonchecker.py
+++ b/src/checkers/jsonchecker.py
@@ -21,10 +21,10 @@ from ..lib.checkers import Checker, JSONType
 log = logging.getLogger(__name__)
 
 
-async def _jq(query: str, data: JSONType, variables: t.Dict[str, str]) -> str:
+async def _jq(query: str, data: JSONType, variables: t.Dict[str, JSONType]) -> str:
     var_args = []
     for var_name, var_value in variables.items():
-        var_args += ["--arg", var_name, var_value]
+        var_args += ["--argjson", var_name, json.dumps(var_value)]
 
     jq_cmd = ["jq"] + var_args + ["-e", query]
     try:

--- a/src/checkers/jsonchecker.py
+++ b/src/checkers/jsonchecker.py
@@ -82,8 +82,9 @@ class JSONChecker(Checker):
     def get_json_schema(cls, data_class: t.Type[ExternalBase]):
         schema = super().get_json_schema(data_class).copy()
         if issubclass(data_class, ExternalGitRepo):
-            schema["required"] = schema.get("required", []) + [
-                "tag-query",
+            schema["anyOf"] = schema.get("anyOf", []) + [
+                {"required": ["tag-query"]},
+                {"required": ["commit-query"]},
             ]
         else:
             schema["required"] = schema.get("required", []) + [
@@ -179,7 +180,7 @@ class JSONChecker(Checker):
         new_version = ExternalGitRef(
             url=external_data.current_version.url,
             commit=results.get("commit"),
-            tag=results["tag"],
+            tag=results.get("tag"),
             branch=None,
             version=results.get("version"),
             timestamp=parse_timestamp(results.get("timestamp")),

--- a/src/checkers/jsonchecker.py
+++ b/src/checkers/jsonchecker.py
@@ -149,6 +149,18 @@ class JSONChecker(Checker):
 
         json_vars: t.Dict[str, JSONType] = {}
 
+        if external_data.parent:
+            assert isinstance(external_data.parent, ExternalBase)
+            # XXX This seemingly redundant extra variable is needed to make Mypy happy
+            parent_data: t.Dict[str, t.Optional[t.Dict[str, JSONType]]]
+            parent_data = {
+                "current": external_data.parent.current_version.json,
+                "new": None,
+            }
+            if external_data.parent.new_version:
+                parent_data["new"] = external_data.parent.new_version.json
+            json_vars["parent"] = parent_data
+
         if isinstance(external_data, ExternalGitRepo):
             return await self._check_git(json_data, json_vars, external_data)
         else:

--- a/src/lib/externaldata.py
+++ b/src/lib/externaldata.py
@@ -205,6 +205,12 @@ class ExternalState(abc.ABC):
     def _asdict(self) -> t.Dict[str, t.Any]:
         return dataclasses.asdict(self)
 
+    @property
+    def json(self) -> t.Dict[str, t.Any]:
+        return self._asdict() | {
+            "timestamp": self.timestamp.isoformat() if self.timestamp else None,
+        }
+
     def matches(self: _ES, other: _ES) -> bool:
         raise NotImplementedError
 
@@ -274,6 +280,12 @@ class ExternalBase(BuilderSource):
 class ExternalFile(ExternalState):
     checksum: MultiDigest
     size: t.Optional[int]
+
+    @property
+    def json(self) -> t.Dict[str, t.Any]:
+        return super().json | {
+            "checksum": self.checksum._asdict(),  # pylint: disable=no-member
+        }
 
     def matches(self, other: ExternalFile):
         for i in (self, other):

--- a/tests/io.github.stedolan.jq.yml
+++ b/tests/io.github.stedolan.jq.yml
@@ -67,11 +67,20 @@ modules:
         commit: 740ffb3c6426d62ac1a54e68d5a13f91479baf9a
         x-checker-data:
           type: json
-          url: https://api.github.com/repos/telegramdesktop/tdesktop/releases/latest
+          url: https://api.github.com/repos/telegramdesktop/tdesktop/releases/tags/v3.7.3
           tag-query: '.tag_name'
           version-query: '.tag_name | sub("^[vV]"; "")'
-          # This one should result in parse error
-          timestamp-query: '.target_commitish'
+
+  - name: tg_owt
+    sources:
+      - type: git
+        url: https://github.com/desktop-app/tg_owt.git
+        x-checker-data:
+          type: json
+          parent-id: tdesktop-git-0
+          commit-data-url: >-
+            "https://github.com/telegramdesktop/tdesktop/raw/\($parent.new.tag)/snap/snapcraft.yaml"
+          commit-query: .parts.webrtc."source-commit"
 
   - name: lib_webrtc
     sources:

--- a/tests/test_jsonchecker.py
+++ b/tests/test_jsonchecker.py
@@ -18,7 +18,7 @@ class TestJSONChecker(unittest.IsolatedAsyncioTestCase):
         checker = ManifestChecker(TEST_MANIFEST)
         ext_data = await checker.check()
 
-        self.assertEqual(len(ext_data), 8)
+        self.assertEqual(len(ext_data), 9)
         for data in ext_data:
             self.assertIsNotNone(data)
             if data.filename == "jq-1.4.tar.gz":
@@ -73,7 +73,13 @@ class TestJSONChecker(unittest.IsolatedAsyncioTestCase):
                 self.assertIsNotNone(data.new_version.timestamp)
                 self.assertIsInstance(data.new_version.timestamp, datetime.datetime)
             elif data.filename == "tdesktop.git":
-                self.assertIsNone(data.new_version)
+                self.assertIsNotNone(data.new_version)
+                self.assertEqual(data.new_version.tag, "v3.7.3")
+            elif data.filename == "tg_owt.git":
+                self.assertIsNotNone(data.new_version)
+                self.assertEqual(
+                    data.new_version.commit, "63a934db1ed212ebf8aaaa20f0010dd7b0d7b396"
+                )
             elif data.filename == "lib_webrtc.git":
                 self.assertIsNone(data.new_version)
             elif data.filename == "tg_angle.git":


### PR DESCRIPTION
These two features are distinct, but coupled together because they depend on the same prior changes, namely reading JSON objects on Python side instead of passing raw bytes to JQ.