### PR TITLE
htmlchecker: Allow using parent source vars in url

### DIFF
--- a/src/checkers/anityachecker.py
+++ b/src/checkers/anityachecker.py
@@ -79,7 +79,9 @@ class AnityaChecker(Checker):
 
     async def _check_data(self, external_data: ExternalData, latest_version):
         url_template = external_data.checker_data["url-template"]
-        latest_url = self._substitute_placeholders(url_template, latest_version)
+        latest_url = self._substitute_template(
+            url_template, self._version_parts(latest_version)
+        )
 
         await self._update_version(
             external_data, latest_version, latest_url, follow_redirects=False
@@ -87,7 +89,9 @@ class AnityaChecker(Checker):
 
     async def _check_git(self, external_data: ExternalGitRepo, latest_version):
         tag_template = external_data.checker_data["tag-template"]
-        latest_tag = self._substitute_placeholders(tag_template, latest_version)
+        latest_tag = self._substitute_template(
+            tag_template, self._version_parts(latest_version)
+        )
 
         new_version = await ExternalGitRef(
             url=external_data.current_version.url,

--- a/src/checkers/htmlchecker.py
+++ b/src/checkers/htmlchecker.py
@@ -138,7 +138,24 @@ class HTMLChecker(Checker):
         assert self.should_check(external_data)
         assert isinstance(external_data, ExternalData)
 
-        url = external_data.checker_data["url"]
+        url_tmpl = external_data.checker_data["url"]
+
+        if external_data.parent:
+            assert isinstance(external_data.parent, ExternalBase)
+            parent_state = (
+                external_data.parent.new_version or external_data.parent.current_version
+            )
+            parent_json = parent_state.json
+            if parent_state.version:
+                parent_json |= self._version_parts(parent_state.version)
+        else:
+            parent_json = {}
+
+        url = self._substitute_template(
+            url_tmpl,
+            {f"parent_{k}": v for k, v in parent_json.items() if v is not None},
+        )
+
         combo_pattern = _get_pattern(external_data.checker_data, "pattern", 2)
         version_pattern = _get_pattern(external_data.checker_data, "version-pattern", 1)
         url_template = external_data.checker_data.get("url-template")

--- a/src/checkers/htmlchecker.py
+++ b/src/checkers/htmlchecker.py
@@ -183,7 +183,9 @@ class HTMLChecker(Checker):
         else:
             assert version_pattern and url_template
             latest_version = _get_latest(version_pattern, 1).group(1)
-            latest_url = self._substitute_placeholders(url_template, latest_version)
+            latest_url = self._substitute_template(
+                url_template, self._version_parts(latest_version)
+            )
 
         abs_url = urllib.parse.urljoin(base=url, url=latest_url)
 

--- a/src/lib/checkers.py
+++ b/src/lib/checkers.py
@@ -105,9 +105,11 @@ class Checker:
             raise CheckerQueryError from err
 
     @staticmethod
-    def _substitute_placeholders(template_string: str, version: str) -> str:
+    def _version_parts(version: str) -> t.Dict[str, str]:
+        """
+        Parse version string and return a dict of named components.
+        """
         version_list = LooseVersion(version).version
-        tmpl = Template(template_string)
         tmpl_vars: t.Dict[str, t.Union[str, int]]
         tmpl_vars = {"version": version}
         for i, version_part in enumerate(version_list):
@@ -118,8 +120,17 @@ class Checker:
                 tmpl_vars["minor"] = version_part
             elif i == 2:
                 tmpl_vars["patch"] = version_part
+        return {k: str(v) for k, v in tmpl_vars.items()}
+
+    @classmethod
+    def _substitute_template(
+        cls,
+        template_string: str,
+        variables: t.Dict[str, t.Any],
+    ) -> str:
+        tmpl = Template(template_string)
         try:
-            return tmpl.substitute(**tmpl_vars)
+            return tmpl.substitute(**variables)
         except (KeyError, ValueError) as err:
             raise CheckerMetadataError("Error substituting template") from err
 

--- a/tests/org.x.xeyes.yml
+++ b/tests/org.x.xeyes.yml
@@ -82,3 +82,26 @@ modules:
           url: https://httpbingo.org/base64/MS4wLjAK
           version-pattern: (\d[\d\.]+\d)
           url-template: https://httpbingo.org/status/404
+
+  - name: parent-child
+    sources:
+      - type: file
+        url: http://example.com/parent.txt
+        sha256: "0000000000000000000000000000000000000000000000000000000000000000"
+        x-checker-data:
+          type: html
+          # echo 'Version: 1.0.0' | base64 -w 0
+          url: http://httpbingo.org/base64/VmVyc2lvbjogMS4wLjAK
+          version-pattern: Version:\s+([\d\.]+)
+          url-template: https://httpbingo.org/response-headers?version=$version
+          source-id: html-parent
+
+      - type: file
+        url: http://example.com/child.txt
+        sha256: "0000000000000000000000000000000000000000000000000000000000000000"
+        x-checker-data:
+          type: html
+          url: https://httpbingo.org/response-headers?version=$parent_version
+          version-pattern: \["([\d\.]+)"\]
+          url-template: https://httpbingo.org/response-headers?version=$version
+          parent-id: html-parent

--- a/tests/test_htmlchecker.py
+++ b/tests/test_htmlchecker.py
@@ -90,6 +90,10 @@ class TestHTMLChecker(unittest.IsolatedAsyncioTestCase):
         self._test_semver_filter(self._find_by_filename(ext_data, "semver.txt"))
         self._test_no_match(self._find_by_filename(ext_data, "libFS-1.0.7.tar.bz2"))
         self._test_invalid_url(self._find_by_filename(ext_data, "libdoesntexist.tar"))
+        self._test_parent_child(
+            self._find_by_filename(ext_data, "parent.txt"),
+            self._find_by_filename(ext_data, "child.txt"),
+        )
 
     def _test_check_with_url_template(self, data):
         self.assertIsNotNone(data)
@@ -164,6 +168,19 @@ class TestHTMLChecker(unittest.IsolatedAsyncioTestCase):
     def _test_invalid_url(self, data):
         self.assertIsNotNone(data)
         self.assertIsNone(data.new_version)
+
+    def _test_parent_child(self, parent, child):
+        self.assertIs(child.parent, parent)
+        self.assertIsNotNone(parent.new_version)
+        self.assertIsNotNone(child.new_version)
+        self.assertEqual(
+            child.new_version.checksum,
+            # curl https://httpbingo.org/response-headers?version=1.0.0 | sha256sum
+            MultiDigest(
+                sha256="da69554c4483e69a2c4e918e252c68e7e17eb2f6b70b6cdb33746a415fc0e687"
+            ),
+        )
+        self.assertEqual(parent.new_version.checksum, child.new_version.checksum)
 
     def _find_by_filename(self, ext_data, filename):
         for data in ext_data:


### PR DESCRIPTION
This makes HTMLChecker's html `url` a template that can be substituted with parent source properties.
Since there is no way to use `or` statements in a string template to alternate between current and new parent source state, we have to do this at checker side: if there is a new version - use it, otherwise - fall back to current version.