### PR TITLE
main: Allow overriding max manifest size

### DIFF
--- a/src/lib/errors.py
+++ b/src/lib/errors.py
@@ -22,6 +22,10 @@ class ManifestLoadError(ManifestError):
     """Error loading flatpak-builder manifest"""
 
 
+class ManifestFileTooLarge(ManifestLoadError):
+    """Manifest file size is too big"""
+
+
 class ManifestUpdateError(ManifestError):
     """Error updating flatpak-builder manifest"""
 

--- a/src/lib/errors.py
+++ b/src/lib/errors.py
@@ -22,6 +22,10 @@ class ManifestLoadError(ManifestError):
     """Error loading flatpak-builder manifest"""
 
 
+class ManifestFileOpenError(ManifestLoadError):
+    """Can't open manifest file"""
+
+
 class ManifestFileTooLarge(ManifestLoadError):
     """Manifest file size is too big"""
 

--- a/src/main.py
+++ b/src/main.py
@@ -386,6 +386,12 @@ def parse_cli_args(cli_args=None):
         help="Enable unsafe features; use only with manifests from trusted sources",
         action="store_true",
     )
+    parser.add_argument(
+        "--max-manifest-size",
+        help="Maximum manifest file size allowed to load",
+        type=int,
+        default=manifest.MAX_MANIFEST_SIZE,
+    )
 
     return parser.parse_args(cli_args)
 
@@ -398,6 +404,7 @@ async def run_with_args(args: argparse.Namespace) -> t.Tuple[int, int, bool]:
 
     options = manifest.CheckerOptions(
         allow_unsafe=args.unsafe,
+        max_manifest_size=args.max_manifest_size,
     )
 
     manifest_checker = manifest.ManifestChecker(args.manifest, options)

--- a/src/main.py
+++ b/src/main.py
@@ -396,7 +396,11 @@ async def run_with_args(args: argparse.Namespace) -> t.Tuple[int, int, bool]:
     should_update = args.update or args.commit_only or args.edit_only
     did_update = False
 
-    manifest_checker = manifest.ManifestChecker(args.manifest, args.unsafe)
+    options = manifest.CheckerOptions(
+        allow_unsafe=args.unsafe,
+    )
+
+    manifest_checker = manifest.ManifestChecker(args.manifest, options)
 
     await manifest_checker.check(args.filter_type)
 

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -20,6 +20,7 @@
 
 from collections import OrderedDict
 import datetime
+import dataclasses
 import typing as t
 import asyncio
 from dataclasses import dataclass
@@ -85,6 +86,11 @@ def _external_source_filter(manifest_path: str, source: str) -> bool:
     return True
 
 
+@dataclasses.dataclass(frozen=True)
+class CheckerOptions:
+    allow_unsafe: bool = False
+
+
 class ManifestChecker:
     class Kind(IntEnum):
         UNKNOWN = 0
@@ -100,12 +106,12 @@ class ManifestChecker:
         failed: int = 0
         total: int = 0
 
-    def __init__(self, manifest: str, unsafe_enabled: bool = False):
+    def __init__(self, manifest: str, options: CheckerOptions = None):
         self.kind = self.Kind.UNKNOWN
         self.app_id: t.Optional[str]
         self.app_id = None
 
-        self.unsafe_enabled = unsafe_enabled
+        self.opts = options or CheckerOptions()
 
         self._root_manifest_path = manifest
         self._root_manifest_dir = os.path.dirname(self._root_manifest_path)


### PR DESCRIPTION
Useful for performance measurements, or for allowing to load legitimately large manifests.