### PR TITLE
externalata: Compare commits if no tag or branch

### DIFF
--- a/src/lib/externaldata.py
+++ b/src/lib/externaldata.py
@@ -472,6 +472,10 @@ class ExternalGitRef(ExternalState):
 
     def is_same_version(self, other: ExternalGitRef):
         assert isinstance(other, type(self))
+        # If only commit is set on both sides, compare it as a version indicator
+        if all(p is None for p in [self.tag, self.branch, other.tag, other.branch]):
+            return self.url == other.url and self.commit == other.commit
+        # otherwise, compare tag an branch
         return (
             self.url == other.url
             and self.tag == other.tag


### PR DESCRIPTION
If source states don't have neither tags nor branches, compare commits to determine if the version has changed (if it's updated or broken).

Fixes https://github.com/flathub/flatpak-external-data-checker/issues/312#issuecomment-1166241371