### PR TITLE
htmlchecker: Support version sorting and filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,8 @@ set single pattern containing two nested match groups for both url and version:
 
 To disable sorting and get first matched version/url, set `sort-matches` to `false`.
 
+The [`versions`](#version-constraining) property is supported.
+
 #### URL templates
 
 The HTML checker also supports building the download URL using

--- a/tests/org.x.xeyes.yml
+++ b/tests/org.x.xeyes.yml
@@ -32,6 +32,34 @@ modules:
           pattern: <link>(https://sourceforge.net/.+/qrupdate-([\d\.]+\d)\.tar\.gz)/download</link>
           sort-matches: false
 
+  - name: libX11
+    sources:
+      - type: archive
+        url: http://some-incorrect.url/libX11.tar.gz
+        sha256: "0000000000000000000000000000000000000000000000000000000000000000"
+        x-checker-data:
+          type: html
+          url: https://www.x.org/releases/individual/lib/
+          version-pattern: libX11-([\d\.]+).tar.gz
+          url-template: libX11-$version.tar.gz
+          versions:
+            ==: 1.7.5
+
+  - name: semver
+    sources:
+      - type: file
+        url: http://example.com/semver.txt
+        sha256: "0000000000000000000000000000000000000000000000000000000000000000"
+        x-checker-data:
+          type: html
+          # printf '%s\n' v1.0.0 v1.0.0+patch1 v2.0.0-rc1 v2.0.0 | base64
+          url: http://httpbingo.org/base64/djEuMC4wCnYxLjAuMCtwYXRjaDEKdjIuMC4wLXJjMQp2Mi4wLjAK
+          version-pattern: v(\d.*)
+          url-template: http://httpbingo.org/base64/encode/$version
+          versions:
+            <: 2.0.0-alpha
+          version-scheme: semantic
+
   - name: libFS
     sources:
       - type: archive

--- a/tests/test_htmlchecker.py
+++ b/tests/test_htmlchecker.py
@@ -86,6 +86,8 @@ class TestHTMLChecker(unittest.IsolatedAsyncioTestCase):
         self._test_combo_pattern_nosort(
             self._find_by_filename(ext_data, "qrupdate-1.1.0.tar.gz")
         )
+        self._test_version_filter(self._find_by_filename(ext_data, "libX11.tar.gz"))
+        self._test_semver_filter(self._find_by_filename(ext_data, "semver.txt"))
         self._test_no_match(self._find_by_filename(ext_data, "libFS-1.0.7.tar.bz2"))
         self._test_invalid_url(self._find_by_filename(ext_data, "libdoesntexist.tar"))
 
@@ -143,6 +145,17 @@ class TestHTMLChecker(unittest.IsolatedAsyncioTestCase):
                 sha256="0000000000000000000000000000000000000000000000000000000000000000"
             ),
         )
+
+    def _test_version_filter(self, data):
+        self.assertIsNotNone(data)
+        self.assertIsNotNone(data.new_version)
+        self.assertEqual(data.new_version.version, "1.7.5")
+
+    def _test_semver_filter(self, data):
+        self.assertIsNotNone(data)
+        self.assertIsNotNone(data.new_version)
+        self.assertIsNotNone(data.new_version.version)
+        self.assertEqual(data.new_version.version, "1.0.0+patch1")
 
     def _test_no_match(self, data):
         self.assertIsNotNone(data)


### PR DESCRIPTION
Adds proper version sorting and filtering to HTMLChecker; `version-scheme` can be set to `loose` (the default, behaves more or less the same as before) or `semantic`.

Fixes #309 