### PR TITLE
README: Document write access for Flatpak version

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ flatpak install --from https://dl.flathub.org/repo/appstream/org.flathub.flatpak
 And run with
 
 ```bash
-flatpak run org.flathub.flatpak-external-data-checker MANIFEST_FILE
+flatpak run --filesystem=MANIFEST_DIR org.flathub.flatpak-external-data-checker MANIFEST_DIR/MANIFEST_FILE
 ```
 
 #### Running in a container


### PR DESCRIPTION
This is a common trap for the unwary. Strictly speaking the `--filesystem` flag
is only needed when running with `--update` or similar but it's easier to just
document it as always needed.

Another nicety not implemented here would be to detect this situation and give a hint in the error message, rather than just dying with "permission denied".