### PR TITLE
Consistently default stable-only to true

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,8 @@ and add a template for source download URL.
     "url-template": "https://github.com/flatpak/flatpak/releases/download/$version/flatpak-$version.tar.xz"
 }
 ```
-Set `stable-only` to `true` to retrieve latest stable version (as recognized by Anitya).
+
+Set `stable-only` to `false` to include unstable releases (as recognized by Anitya).
 
 The [`versions`](#version-constraining) property is supported.
 

--- a/src/checkers/anityachecker.py
+++ b/src/checkers/anityachecker.py
@@ -48,7 +48,7 @@ class AnityaChecker(Checker):
             "baseurl", "https://release-monitoring.org"
         )
         versions_url = URL(instance_url) / "api/v2/versions/"
-        stable_only = external_data.checker_data.get("stable-only", False)
+        stable_only = external_data.checker_data.get("stable-only", True)
         constraints = external_data.checker_data.get("versions", {}).items()
 
         query = {"project_id": external_data.checker_data["project-id"]}

--- a/src/checkers/pypichecker.py
+++ b/src/checkers/pypichecker.py
@@ -73,7 +73,7 @@ class PyPIChecker(Checker):
             (o, Version(v))
             for o, v in external_data.checker_data.get("versions", {}).items()
         ]
-        stable_only = external_data.checker_data.get("stable-only", False)
+        stable_only = external_data.checker_data.get("stable-only", True)
 
         async with self.session.get(f"{PYPI_INDEX}/{package_name}/json") as response:
             pypi_data = await response.json()

--- a/tests/org.flatpak.Flatpak.yml
+++ b/tests/org.flatpak.Flatpak.yml
@@ -20,6 +20,7 @@ modules:
         x-checker-data:
           type: anitya
           project-id: 6377
+          stable-only: false
           versions:
             ==: "1.10.1"
           url-template: https://github.com/flatpak/flatpak/releases/download/$version/flatpak-$version.tar.xz
@@ -43,6 +44,7 @@ modules:
         x-checker-data:
           type: anitya
           project-id: 1157
+          # Leaving stable-only unset to at least exercise the default path
           url-template: https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs$version0$version1$version2/ghostscript-$version.tar.xz
 
   - name: gnuradio-iqbal


### PR DESCRIPTION
Previously, gnomechecker would default stable-only to true, but
anityachecker and pypichecker defaulted it to false.

true is the sensible default.
