### PR TITLE
gnomechecker: Don't crash if no versions satisfy constraint

### DIFF
--- a/src/checkers/gnomechecker.py
+++ b/src/checkers/gnomechecker.py
@@ -70,18 +70,21 @@ class GNOMEChecker(Checker):
         if constraints:
             filtered_versions = filter_versions(filtered_versions, constraints)
 
-        if stable_only:
-            try:
-                latest_version = list(filter(_is_stable, filtered_versions))[-1]
-            except IndexError:
+        try:
+            if stable_only:
+                try:
+                    latest_version = list(filter(_is_stable, filtered_versions))[-1]
+                except IndexError:
+                    latest_version = filtered_versions[-1]
+                    log.warning(
+                        "Couldn't find any stable version for %s, selecting latest %s",
+                        project_name,
+                        latest_version,
+                    )
+            else:
                 latest_version = filtered_versions[-1]
-                log.warning(
-                    "Couldn't find any stable version for %s, selecting latest %s",
-                    project_name,
-                    latest_version,
-                )
-        else:
-            latest_version = filtered_versions[-1]
+        except IndexError as e:
+            raise CheckerQueryError("No matching versions") from e
 
         proj_files = downloads[project_name][latest_version]
 

--- a/tests/org.gnome.baobab.json
+++ b/tests/org.gnome.baobab.json
@@ -64,6 +64,23 @@
                     }
                 }
             ]
+        },
+        {
+            "name" : "cairo-static",
+            "sources" : [
+                {
+                    "type": "archive",
+                    "url": "https://gitlab.freedesktop.org/cairo/cairo/-/archive/1.17.6/cairo-1.17.6.tar.gz",
+                    "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "x-checker-data": {
+                        "type": "gnome",
+                        "name": "cairo",
+                        "versions": {
+                            ">": "9999.0.0"
+                        }
+                    }
+                }
+            ]
         }
     ]
 }

--- a/tests/test_gnomechecker.py
+++ b/tests/test_gnomechecker.py
@@ -52,6 +52,10 @@ class TestGNOMEChecker(unittest.IsolatedAsyncioTestCase):
         ext_data = await checker.check()
 
         for data in ext_data:
+            if data.filename == "cairo-1.17.6.tar.gz":
+                self.assertIsNone(data.new_version)
+                continue
+
             self.assertIsNotNone(data.new_version)
             self.assertIsNotNone(data.new_version.checksum)
             self.assertIsInstance(data.new_version.checksum, MultiDigest)


### PR DESCRIPTION
Fixes #326
