### PR TITLE
Show base branch in PR title

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -438,8 +438,13 @@ def open_pr(
         log_url = f"https://github.com/{gh_repo_name}/actions/runs/{gh_run_id}"
         pr_message += f"\n\n[📋 View External data checker logs]({log_url})"
 
+    subject = change.subject or ""
+
+    if base != origin_repo.default_branch:
+        subject = f"[{base}] {subject}"
+
     pr = origin_repo.create_pull(
-        change.subject,
+        subject,
         pr_message,
         base,
         head,

--- a/src/main.py
+++ b/src/main.py
@@ -444,10 +444,10 @@ def open_pr(
         subject = f"[{base}] {subject}"
 
     pr = origin_repo.create_pull(
-        subject,
-        pr_message,
-        base,
-        head,
+        title=subject,
+        body=pr_message,
+        base=base,
+        head=head,
         maintainer_can_modify=True,
     )
     log.info("Opened pull request %s", pr.html_url)


### PR DESCRIPTION
f-e-d-c is currently used by [com.riverbankcomputing.PyQt.BaseApp](https://github.com/flathub/com.riverbankcomputing.PyQt.BaseApp) on 3 different branches. Having the branch (e.g. 5.15-22.08 or 6.3) would make it possible to see which branch is targeted directly in the Notification or the PR list.

Note: This is currently not tested