### PR TITLE
update jetbrains checker to add support for arm64 builds

### DIFF
--- a/src/checkers/jetbrainschecker.py
+++ b/src/checkers/jetbrainschecker.py
@@ -7,6 +7,11 @@ from ..lib.checkers import Checker
 
 log = logging.getLogger(__name__)
 
+DOWNLOAD_NODE_SUFFIX = {
+    "x86_64": "",
+    "aarch64": "ARM64",
+}
+
 
 class JetBrainsChecker(Checker):
     CHECKER_DATA_TYPE = "jetbrains"
@@ -33,9 +38,8 @@ class JetBrainsChecker(Checker):
             result = await response.json()
             data = result[code][0]
 
-        release = data["downloads"][
-            self._get_download_node_name(external_data.arches[0])
-        ]
+        arch = external_data.arches[0]
+        release = data["downloads"][f"linux{DOWNLOAD_NODE_SUFFIX[arch]}"]
 
         async with self.session.get(release["checksumLink"]) as response:
             result = await response.text()
@@ -50,11 +54,3 @@ class JetBrainsChecker(Checker):
         )
 
         external_data.set_new_version(new_version)
-
-    @staticmethod
-    def _get_download_node_name(arch: str) -> str:
-        mapping = {
-            "x86_64": "",
-            "aarch64": "ARM64",
-        }
-        return f"linux{mapping[arch]}"

--- a/src/checkers/jetbrainschecker.py
+++ b/src/checkers/jetbrainschecker.py
@@ -16,7 +16,6 @@ class JetBrainsChecker(Checker):
             "code": {"type": "string"},
             # TODO: add enum here
             "release-type": {"type": "string"},
-            "arch": {"type": "string"},
         },
         "required": ["code"],
     }
@@ -34,12 +33,9 @@ class JetBrainsChecker(Checker):
             result = await response.json()
             data = result[code][0]
 
-        arch = (
-            external_data.checker_data["arch"]
-            if "arch" in external_data.checker_data
-            else "x86_64"
-        )
-        release = data["downloads"][self._get_download_node_name(arch)]
+        release = data["downloads"][
+            self._get_download_node_name(external_data.arches[0])
+        ]
 
         async with self.session.get(release["checksumLink"]) as response:
             result = await response.text()

--- a/src/checkers/jetbrainschecker.py
+++ b/src/checkers/jetbrainschecker.py
@@ -20,10 +20,6 @@ class JetBrainsChecker(Checker):
         },
         "required": ["code"],
     }
-    DOWNLOAD_NODE_SUFFIX = {
-        "x86_64": "",
-        "aarch64": "ARM64",
-    }
 
     async def check(self, external_data: ExternalBase):
         assert self.should_check(external_data)
@@ -43,8 +39,7 @@ class JetBrainsChecker(Checker):
             if "arch" in external_data.checker_data
             else "x86_64"
         )
-        download_node = f"linux{DOWNLOAD_NODE_SUFFIX[arch]}"
-        release = data["downloads"][download_node]
+        release = data["downloads"][self._get_download_node_name(arch)]
 
         async with self.session.get(release["checksumLink"]) as response:
             result = await response.text()
@@ -59,3 +54,11 @@ class JetBrainsChecker(Checker):
         )
 
         external_data.set_new_version(new_version)
+
+    @staticmethod
+    def _get_download_node_name(arch: str) -> str:
+        mapping = {
+            "x86_64": "",
+            "aarch64": "ARM64",
+        }
+        return f"linux{mapping[arch]}"

--- a/src/checkers/jetbrainschecker.py
+++ b/src/checkers/jetbrainschecker.py
@@ -16,8 +16,13 @@ class JetBrainsChecker(Checker):
             "code": {"type": "string"},
             # TODO: add enum here
             "release-type": {"type": "string"},
+            "arch": {"type": "string"},
         },
         "required": ["code"],
+    }
+    DOWNLOAD_NODE_SUFFIX = {
+        "x86_64": "",
+        "aarch64": "ARM64",
     }
 
     async def check(self, external_data: ExternalBase):
@@ -33,7 +38,9 @@ class JetBrainsChecker(Checker):
             result = await response.json()
             data = result[code][0]
 
-        release = data["downloads"]["linux"]
+        arch = external_data.checker_data["arch"] if "arch" in external_data.checker_data else "x86_64"
+        download_node = f"linux{DOWNLOAD_NODE_SUFFIX[arch]}"
+        release = data["downloads"][download_node]
 
         async with self.session.get(release["checksumLink"]) as response:
             result = await response.text()

--- a/src/checkers/jetbrainschecker.py
+++ b/src/checkers/jetbrainschecker.py
@@ -38,7 +38,11 @@ class JetBrainsChecker(Checker):
             result = await response.json()
             data = result[code][0]
 
-        arch = external_data.checker_data["arch"] if "arch" in external_data.checker_data else "x86_64"
+        arch = (
+            external_data.checker_data["arch"]
+            if "arch" in external_data.checker_data
+            else "x86_64"
+        )
         download_node = f"linux{DOWNLOAD_NODE_SUFFIX[arch]}"
         release = data["downloads"][download_node]
 

--- a/src/checkers/jetbrainschecker.py
+++ b/src/checkers/jetbrainschecker.py
@@ -7,9 +7,9 @@ from ..lib.checkers import Checker
 
 log = logging.getLogger(__name__)
 
-DOWNLOAD_NODE_SUFFIX = {
-    "x86_64": "",
-    "aarch64": "ARM64",
+_JB_ARCH_MAP = {
+    "x86_64": "linux",
+    "aarch64": "linuxARM64",
 }
 
 

--- a/src/checkers/jetbrainschecker.py
+++ b/src/checkers/jetbrainschecker.py
@@ -38,8 +38,7 @@ class JetBrainsChecker(Checker):
             result = await response.json()
             data = result[code][0]
 
-        arch = external_data.arches[0]
-        release = data["downloads"][f"linux{DOWNLOAD_NODE_SUFFIX[arch]}"]
+        release = data["downloads"][_JB_ARCH_MAP[external_data.arches[0]]]
 
         async with self.session.get(release["checksumLink"]) as response:
             result = await response.text()


### PR DESCRIPTION
JetBrains publishes separate builds for Linux ARM64. This adds support to jetbrains checker to include arch property and grab the appropriate download node from the call to fetch available builds.