### PR TITLE
checker: disable content type check in _get_json

### DIFF
--- a/src/checkers/__init__.py
+++ b/src/checkers/__init__.py
@@ -4,6 +4,7 @@ import logging
 from distutils.version import LooseVersion
 from string import Template
 import datetime
+import json
 import re
 import typing as t
 import importlib
@@ -120,7 +121,10 @@ class Checker:
                         return yaml.load(await response.read())
                     except ruamel.yaml.error.YAMLError as err:
                         raise CheckerQueryError("Failed to parse YAML") from err
-                return await response.json()
+                try:
+                    return await response.json(content_type=None)
+                except json.JSONDecodeError as err:
+                    raise CheckerQueryError("Failed to parse JSON") from err
         except NETWORK_ERRORS as err:
             raise CheckerQueryError from err
 


### PR DESCRIPTION
It seems that `aiohttp.ClientResponse.json` refuses to decode if the response content type isn't `application/json`. To workaround bad APIs in the wild ([example](https://buildbot.flathub.org/#/builders/6/builds/26538)) that returns valid JSON with an incorrect content type, disable this check.