### PR TITLE
main: Fix git config --get-all error handling

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -138,10 +138,12 @@ def ensure_git_safe_directory(checkout: t.Union[Path, str]):
         safe_dirs_output = subprocess.check_output(
             ["git", "config", "--get-all", "safe.directory"]
         )
-    except subprocess.CalledProcessError:
-        # Assume git is too old to enforce safe.directory. The oldest
-        # version to have it is 2.30.3, I believe.
-        return
+    except subprocess.CalledProcessError as err:
+        # git config --get-all will return 1 if the key doesn't exist.
+        # Re-raise the error for anything else.
+        if err.returncode != 1:
+            raise
+        safe_dirs_output = b""
 
     safe_dirs = safe_dirs_output.decode("utf-8").split()
     if checkout in safe_dirs:


### PR DESCRIPTION
It will return 1 if the key doesn't exist, not if git doesn't know about the key. Even old git is happy to get and set `safe.directory`.

This time I actually ran it in a container as root and it worked:

```
DEBUG   src.main: $ git config --system --add safe.directory /home/dan/src/eos-google-chrome-app
INFO    src.main: Committing updates
DEBUG   src.main: $ git checkout HEAD@{0}
Note: switching to 'HEAD@{0}'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at 8630237 Merge pull request #157 from endlessm/T28855-appstream-domain
M	com.google.Chrome.appdata.xml
M	com.google.Chrome.json
DEBUG   src.main: $ git commit -am Update chrome.deb to 111.0.5563.64-1
[detached HEAD d5c7bb2] Update chrome.deb to 111.0.5563.64-1
 Author: Me <me@example.com>
 2 files changed, 4 insertions(+), 3 deletions(-)
DEBUG   src.main: $ git checkout -b update-64153f1
Switched to a new branch 'update-64153f1'
INFO    src.main: Check finished with 0 error(s)
```