### PR TITLE
Versions of the format 0.x.y should be considered stable

### DIFF
--- a/src/checkers/gnomechecker.py
+++ b/src/checkers/gnomechecker.py
@@ -32,7 +32,7 @@ def _is_stable(version: str) -> bool:
     major, minor = ver_list[:2]
     if set(ver_list[1:]) & {"alpha", "beta", "rc"}:
         return False
-    if int(major) < 40 and len(ver_list) > 2:
+    if int(major) > 0 and int(major) < 40 and len(ver_list) > 2:
         return (int(minor) % 2) == 0
     # XXX If we didn't see any indication that the version is a prerelease,
     # assume it's a normal (stable) release


### PR DESCRIPTION
Fixes #338, fixes #358

This will consider all versions with a maj́or version of 0 as stable when using the gnome checker.

---

This is currently not covered by tests, as alleyoop only has one version branch 0.9.x: https://github.com/flathub/flatpak-external-data-checker/blob/890dd4b8d6fca69539ccdc5c53727f55716877fc/tests/org.gnome.baobab.json#L15-L18
this will not trigger the behaviour, as it will fallback to the single unstable version branch if no other stable version is available.