### PR TITLE
CI (workflows): bump actions version; fix Node deprecation warning; add LF as default eol

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Ref: https://git-scm.com/docs/gitattributes
+* text=auto eol=lf

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,7 +22,7 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - name: Install dependencies
         run: |
@@ -42,10 +42,10 @@ jobs:
     runs-on: ubuntu-latest
     container: debian:bullseye
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Prime pip cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: |
@@ -64,7 +64,7 @@ jobs:
             lxml-stubs
 
       - name: Prime mypy cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .mypy_cache
           key: |
@@ -83,14 +83,14 @@ jobs:
     name: Build and test container
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Build container
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: .
           file: ./Dockerfile
@@ -118,7 +118,7 @@ jobs:
 
       - name: Login to registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.DOCKER_REGISTRY }}
           username: ${{ github.actor }}
@@ -126,7 +126,7 @@ jobs:
 
       - name: Push image to registry
         if: github.event_name != 'pull_request'
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: .
           file: ./Dockerfile


### PR DESCRIPTION
This PR fixes the Node 12 deprecation warning displayed in the action runs.

## Changes

- Bump the `actions/checkout` version from `v2` (Node 12) to `v3` (Node 16).
- Bump the `actions/cache` version from `v2` (Node 12) to `v3` (Node 16).
- Bump the `docker/setup-buildx-action` to `v2`.
- Bump the `docker/build-push-action` to `v4`.
- Bump the `docker/login-action` to `v2`.
- Set LF as the default eol in `.gitattributes`. (I performed the latest 2 commits from Windows, thus this change will allow others to work on PRs from Windows without worrying about it being set to CRLF)