### PR TITLE
tests: Stop using ghostscript in tests

### DIFF
--- a/tests/org.flatpak.Flatpak.yml
+++ b/tests/org.flatpak.Flatpak.yml
@@ -36,16 +36,16 @@ modules:
           stable-only: true
           url-template: https://boostorg.jfrog.io/artifactory/main/release/$version/source/boost_${major}_${minor}_$patch.tar.bz2
 
-  - name: ghostscript
+  - name: glib-networking
     sources:
       - type: archive
-        url: https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs926/ghostscript-9.26.tar.xz
-        sha256: 90ed475f37584f646e9ef829932b2525d5c6fc2e0147e8d611bc50aa0e718598
+        url: https://download.gnome.org/sources/glib-networking/2.74/glib-networking-2.74.0.tar.xz
+        sha256: 1f185aaef094123f8e25d8fa55661b3fd71020163a0174adb35a37685cda613b
         x-checker-data:
           type: anitya
-          project-id: 1157
+          project-id: 21353
           # Leaving stable-only unset to at least exercise the default path
-          url-template: https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs$version0$version1$version2/ghostscript-$version.tar.xz
+          url-template: https://download.gnome.org/sources/glib-networking/$version0.$version1/glib-networking-$version.tar.xz
 
   - name: gnuradio-iqbal
     buildsystem: cmake

--- a/tests/test_anityachecker.py
+++ b/tests/test_anityachecker.py
@@ -20,16 +20,16 @@ class TestAnityaChecker(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(len(ext_data), 5)
         for data in ext_data:
-            if data.filename == "ghostscript-9.26.tar.xz":
+            if data.filename == "glib-networking-2.74.0.tar.xz":
                 self.assertIsNotNone(data.new_version)
                 self.assertIsInstance(data.new_version, ExternalFile)
                 self.assertRegex(
                     data.new_version.url,
-                    r"^https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs[\d]+/ghostscript-[\d.]+.tar.xz$",
+                    r"^https://download.gnome.org/sources/glib-networking/\d+.\d+/glib-networking-[\d.]+.tar.xz$",
                 )
                 self.assertIsNotNone(data.new_version.version)
                 self.assertGreater(
-                    LooseVersion(data.new_version.version), LooseVersion("9.26")
+                    LooseVersion(data.new_version.version), LooseVersion("2.76")
                 )
                 self.assertIsInstance(data.new_version.size, int)
                 self.assertGreater(data.new_version.size, 0)
@@ -38,7 +38,7 @@ class TestAnityaChecker(unittest.IsolatedAsyncioTestCase):
                 self.assertNotEqual(
                     data.new_version.checksum,
                     MultiDigest(
-                        sha256="90ed475f37584f646e9ef829932b2525d5c6fc2e0147e8d611bc50aa0e718598"
+                        sha256="1f185aaef094123f8e25d8fa55661b3fd71020163a0174adb35a37685cda613b",
                     ),
                 )
             elif data.filename == "boost_1_74_0.tar.bz2":


### PR DESCRIPTION
One of the tests exercises the ability to use parsed components of versions in URL patterns.

Ghostscript uses version numbers of the form 10.01.0. Since the components are treated as digits, the $version1 variable is set to "1" not "01", and so this test fails.

See https://github.com/flathub/flatpak-external-data-checker/issues/360.

To work around this bug to unbreak the test suite, switch to a different module.

I think this will unblock #361.