### PR TITLE
Parse datetimes with region/city format in HTTP headers

### DIFF
--- a/src/lib/utils.py
+++ b/src/lib/utils.py
@@ -57,6 +57,14 @@ log = logging.getLogger(__name__)
 
 def _extract_timestamp(info):
     date_str = info.get("Last-Modified") or info.get("Date")
+    return parse_date_header(date_str)
+
+
+def parse_date_header(date_str):
+    """Parse a stringified date, from a Last-Modified or Date header.
+
+    In addition to standard(ish) formats, non-standard formats where the
+    timezone is a named zone rather than an offset are detected and handled."""
     list_zones = list(zoneinfo.available_timezones())
     invalid_zones = [e for e in list_zones if e not in ("GMT", "UTC")]
     if any((match_tz := tz) in date_str for tz in invalid_zones):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -36,7 +36,7 @@ from src.lib.utils import (
     filter_versions,
     filter_versioned_items,
     FallbackVersion,
-    _extract_timestamp,
+    parse_date_header,
     get_extra_data_info_from_url,
     Command,
     dump_manifest,
@@ -192,10 +192,15 @@ class TestParseHTTPDate(unittest.TestCase):
         for date_str in [
             "Wed, 20 Jan 2021 15:25:15 UTC",
             "Wed, 20-Jan-2021 15:25:15 UTC",
+            "Wed, 20-Jan-2021 15:25:15 GMT",
             "Wed, 20 Jan 2021 15:25:15 +0000",
             "Wed, 20 Jan 2021 18:25:15 +0300",
+            "Wed, 20 Jan 2021 07:25:15 -0800",
+            # https://github.com/flathub/flatpak-external-data-checker/issues/370
+            "Wed, 20 Jan 2021 23:25:15 +0800",
+            "Wed, 20 Jan 2021 23:25:15 Asia/Shanghai",
         ]:
-            parsed = _extract_timestamp({"Date": date_str})
+            parsed = parse_date_header(date_str)
             self.assertEqual(
                 parsed,
                 datetime(
@@ -208,7 +213,7 @@ class TestParseHTTPDate(unittest.TestCase):
 
     @unittest.expectedFailure
     def test_parse_invalid(self):
-        self.assertIsNotNone(_extract_timestamp({"Date": "some broken string"}))
+        self.assertIsNotNone(parse_date_header("some broken string"))
 
 
 class TestDownload(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
Fixes https://github.com/flathub/flatpak-external-data-checker/issues/370
Fixes https://github.com/flathub/flatpak-external-data-checker/issues/205

```sh
→ flatpak run --branch=master org.flathub.flatpak-external-data-checker --verbose com.netease.CloudMusic.json
DEBUG   src.manifest: Data is not external: no "url" property
DEBUG   src.manifest: Data is not external: no "url" property
DEBUG   src.manifest: Data is not external: no "url" property
DEBUG   src.manifest: Data is not external: no "url" property
DEBUG   src.manifest: Data is not external: no "url" property
INFO    src.manifest: Checking 2 external data items
INFO    src.manifest: Skipped check [1/2] archive keyutils/keyutils-1.6.3.tar.gz (from com.netease.CloudMusic.json)
INFO    src.manifest: Started check [2/2] extra-data CloudMusic/netease-cloud-music.deb (from com.netease.CloudMusic.json)
DEBUG   src.manifest: Source extra-data CloudMusic/netease-cloud-music.deb: applying URLChecker
DEBUG   src.lib.externaldata: Source netease-cloud-music.deb: no remote data change
DEBUG   src.manifest: Source extra-data CloudMusic/netease-cloud-music.deb: got new 2 from URLChecker, skipping remaining checkers
INFO    src.manifest: Finished check [2/2] extra-data CloudMusic/netease-cloud-music.deb (from com.netease.CloudMusic.json)
INFO    src.main: Check finished with 0 error(s)

→ flatpak run --branch=stable org.flathub.flatpak-external-data-checker --verbose com.netease.CloudMusic.json
DEBUG   src.manifest: Data is not external: no "url" property
DEBUG   src.manifest: Data is not external: no "url" property
DEBUG   src.manifest: Data is not external: no "url" property
DEBUG   src.manifest: Data is not external: no "url" property
DEBUG   src.manifest: Data is not external: no "url" property
INFO    src.manifest: Checking 2 external data items
INFO    src.manifest: Skipped check [1/2] archive keyutils/keyutils-1.6.3.tar.gz (from com.netease.CloudMusic.json)
INFO    src.manifest: Started check [2/2] extra-data CloudMusic/netease-cloud-music.deb (from com.netease.CloudMusic.json)
DEBUG   src.manifest: Source extra-data CloudMusic/netease-cloud-music.deb: applying URLChecker
ERROR   src.manifest: Failed to check extra-data CloudMusic/netease-cloud-music.deb with URLChecker: Cannot parse date/time: Mon, 29 Apr 2019 10:43:55 Asia/Shanghai
WARNING src.main: Check finished with 1 error(s)

```

I'm not sure if this is an acceptable approach but at least it gets rid of the failure and I think I didn't break anything.

Thanks!