### PR TITLE
Always create description tag

### DIFF
--- a/src/lib/appdata.py
+++ b/src/lib/appdata.py
@@ -83,6 +83,12 @@ def add_release(
     releases.insert(0, release)
     _fill_padding(release)
 
+    description = ElementTree.Element("description")
+    description.text = ''
+
+    release.append(description)
+    _fill_padding(description)
+
     tree.write(
         dst,
         # XXX: lxml uses single quotes for doctype line if generated with

--- a/src/lib/appdata.py
+++ b/src/lib/appdata.py
@@ -91,7 +91,8 @@ def add_release(
 
     # Indent the opening <description> tag one level
     # deeper than the <release> tag.
-    release.text = "\n" + ((releases.text[1::2]) * 3)
+    if releases.text:
+        release.text = "\n" + ((releases.text[1::2]) * 3)
 
     # Indent the closing </release> tag by the same amount as the opening
     # <release> tag (which we know to be the first child of <releases> since

--- a/src/lib/appdata.py
+++ b/src/lib/appdata.py
@@ -84,10 +84,20 @@ def add_release(
     _fill_padding(release)
 
     description = ElementTree.Element("description")
-    description.text = ''
 
+    # Give <description> a closing </description> rather than it being
+    # self-closing
+    description.text = ""
+
+    # Indent the opening <description> tag one level
+    # deeper than the <release> tag.
+    release.text = "\n" + ((releases.text[1::2]) * 3)
+
+    # Indent the closing </release> tag by the same amount as the opening
+    # <release> tag (which we know to be the first child of <releases> since
+    # we just prepended it above)
+    description.tail = releases.text
     release.append(description)
-    _fill_padding(description)
 
     tree.write(
         dst,

--- a/tests/test_appdata.py
+++ b/tests/test_appdata.py
@@ -73,7 +73,7 @@ class TestAddRelease(unittest.TestCase):
 <component type="desktop">
    <releases>
       <release version="4.5.6" date="2020-02-02">
-        <description></description>
+         <description></description>
       </release>
       <release version="1.2.3" date="2019-01-01"/>
        <release version="1.2.3" date="2019-01-01"/>

--- a/tests/test_appdata.py
+++ b/tests/test_appdata.py
@@ -55,6 +55,81 @@ class TestAddRelease(unittest.TestCase):
             """.strip(),
         )
 
+    @unittest.expectedFailure
+    def test_four_space_no_releases_element(self):
+        # FIXME: This ends up indenting <releases> correctly, but
+        # <release> and <description> incorrectly get the default 2-space
+        # indent.
+        self._do_test(
+            """
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+    <id>com.example.Workaround</id>
+    <name>My history is a mystery</name>
+</component>
+            """.strip(),
+            """
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+    <id>com.example.Workaround</id>
+    <name>My history is a mystery</name>
+    <releases>
+        <release version="4.5.6" date="2020-02-02">
+            <description></description>
+        </release>
+    </releases>
+</component>
+            """.strip(),
+        )
+
+    def test_four_space_one_prior_release(self):
+        self._do_test(
+            """
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+    <releases>
+        <release version="1.2.3" date="2019-01-01"/>
+    </releases>
+</component>
+            """.strip(),
+            """
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+    <releases>
+        <release version="4.5.6" date="2020-02-02">
+            <description></description>
+        </release>
+        <release version="1.2.3" date="2019-01-01"/>
+    </releases>
+</component>
+            """.strip(),
+        )
+
+    def test_four_space_many_prior_releases(self):
+        self._do_test(
+            """
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+    <releases>
+        <release version="1.2.3" date="2019-01-01"/>
+        <release version="1.1.2" date="2018-01-01"/>
+    </releases>
+</component>
+            """.strip(),
+            """
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+    <releases>
+        <release version="4.5.6" date="2020-02-02">
+            <description></description>
+        </release>
+        <release version="1.2.3" date="2019-01-01"/>
+        <release version="1.1.2" date="2018-01-01"/>
+    </releases>
+</component>
+            """.strip(),
+        )
+
     def test_mixed_indentation(self):
         """This input uses 3-space indentation for one existing <release> and 4-space
         for another. Match the top one."""

--- a/tests/test_appdata.py
+++ b/tests/test_appdata.py
@@ -46,7 +46,9 @@ class TestAddRelease(unittest.TestCase):
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
   <releases>
-    <release version="4.5.6" date="2020-02-02"/>
+    <release version="4.5.6" date="2020-02-02">
+      <description></description>
+    </release>
     <release version="1.2.3" date="2019-01-01"/>
   </releases>
 </component>
@@ -70,7 +72,9 @@ class TestAddRelease(unittest.TestCase):
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
    <releases>
-      <release version="4.5.6" date="2020-02-02"/>
+      <release version="4.5.6" date="2020-02-02">
+        <description></description>
+      </release>
       <release version="1.2.3" date="2019-01-01"/>
        <release version="1.2.3" date="2019-01-01"/>
    </releases>
@@ -119,7 +123,9 @@ class TestAddRelease(unittest.TestCase):
 <component type="desktop">
   <!-- I am the walrus -->
   <releases>
-    <release version="4.5.6" date="2020-02-02"/>
+    <release version="4.5.6" date="2020-02-02">
+      <description></description>
+    </release>
     <release version="1.2.3" date="2019-01-01"/>
   </releases>
 </component>
@@ -137,14 +143,16 @@ class TestAddRelease(unittest.TestCase):
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
   <releases>
-    <release version="4.5.6" date="2020-02-02"/>
+    <release version="4.5.6" date="2020-02-02">
+      <description></description>
+    </release>
   </releases>
 </component>
             """.strip(),
         )
 
     def test_empty_releases(self):
-        """No whitespace is generated between <release /> and </releases>."""
+        """No whitespace is generated between </release> and </releases>."""
         self._do_test(
             """
 <?xml version="1.0" encoding="UTF-8"?>
@@ -156,7 +164,9 @@ class TestAddRelease(unittest.TestCase):
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
   <releases>
-    <release version="4.5.6" date="2020-02-02"/>
+    <release version="4.5.6" date="2020-02-02">
+      <description></description>
+    </release>
   </releases>
 </component>
             """.strip(),
@@ -186,7 +196,9 @@ SentUpstream: 2014-05-22
 -->
   <name>First element needed</name>
   <releases>
-    <release version="4.5.6" date="2020-02-02"/>
+    <release version="4.5.6" date="2020-02-02">
+      <description></description>
+    </release>
   </releases>
 </application>
             """.strip(),
@@ -219,7 +231,9 @@ SentUpstream: 2014-05-22
 -->
 <application>
   <releases>
-    <release version="4.5.6" date="2020-02-02"/>
+    <release version="4.5.6" date="2020-02-02">
+      <description></description>
+    </release>
   </releases>
 </application>
             """.strip(),
@@ -238,7 +252,9 @@ SentUpstream: 2014-05-22
 <component type="desktop">
   <name>🍦 &amp; 🎂</name>
   <releases>
-    <release version="4.5.6" date="2020-02-02"/>
+    <release version="4.5.6" date="2020-02-02">
+      <description></description>
+    </release>
   </releases>
 </component>
             """.strip(),
@@ -259,7 +275,9 @@ SentUpstream: 2014-05-22
 <component type="desktop">
   <name>🦝 &#38; 🍒</name>
   <releases>
-    <release version="4.5.6" date="2020-02-02"/>
+    <release version="4.5.6" date="2020-02-02">
+      <description></description>
+    </release>
   </releases>
 </component>
             """.strip(),


### PR DESCRIPTION
I think it makes sense to create these empty tags always. Even if it means there will be a few more bytes to download.

I hope this will motivate some more maintainers to actually fill out the description. 

Also it will be handy for me, cause I always need to look up the exact syntax whenever I get an update, as I usually forget it.