### PR TITLE
Report real URL for bad content types

### DIFF
--- a/src/lib/utils.py
+++ b/src/lib/utils.py
@@ -165,9 +165,13 @@ async def get_extra_data_info_from_url(
                 # wrong
                 actual_content_type = magic.from_buffer(chunk, mime=True)
                 if content_type_rejected(actual_content_type):
+                    if real_url != url:
+                        suffix = f" (redirected from '{url}')"
+                    else:
+                        suffix = ""
                     raise CheckerFetchError(
                         f"Wrong content type '{actual_content_type}' received "
-                        f"from '{url}'"
+                        f"from '{real_url}'{suffix}"
                     )
 
             checksum.update(chunk)


### PR DESCRIPTION
We believe that a KDE mirror is responsible for returning text/plain for source tarballs, but the raised exception only includes the original URL, not the result of following any redirects.

Report both, if they differ.

See #315