### PR TITLE
CI: bump actions/checkout to v4

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,7 +22,7 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install dependencies
         run: |
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     container: debian:bullseye
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Prime pip cache
         uses: actions/cache@v3
@@ -83,7 +83,7 @@ jobs:
     name: Build and test container
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2


### PR DESCRIPTION
This PR bumps the `actions/checkout` version from v3 (Node 16) to v4 (Node 20) as Node 16 is reaching eol soon.
Ref. https://nodejs.org/en/blog/announcements/nodejs16-eol