### PR TITLE
Fix tests and add builddeps of python3-apt to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,11 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 ADD dependencies.apt.txt ./
 
+RUN printf "deb-src http://deb.debian.org/debian bullseye main\ndeb-src http://deb.debian.org/debian-security/ bullseye-security main\ndeb-src http://deb.debian.org/debian bullseye-updates main" >> /etc/apt/sources.list
+
 RUN apt-get update && \
     xargs apt-get install --no-install-recommends -y < dependencies.apt.txt && \
+    apt-get --no-install-recommends -y build-dep python3-apt && \
     apt-get clean && \
     rmdir /var/cache/apt/archives/partial
 

--- a/tests/test_jsonchecker.py
+++ b/tests/test_jsonchecker.py
@@ -26,7 +26,7 @@ class TestJSONChecker(unittest.IsolatedAsyncioTestCase):
                 self.assertNotEqual(data.current_version.url, data.new_version.url)
                 self.assertRegex(
                     data.new_version.url,
-                    r"^https://github.com/stedolan/jq/releases/download/jq-[0-9\.\w]+/jq-[0-9\.\w]+\.tar.gz$",
+                    r"^https://github.com/jqlang/jq/releases/download/jq-[0-9\.\w]+/jq-[0-9\.\w]+\.tar.gz$",
                 )
                 self.assertIsInstance(data.new_version.size, int)
                 self.assertGreater(data.new_version.size, 0)


### PR DESCRIPTION
The tests broke a bit after https://github.com/flathub/flatpak-external-data-checker/pull/391

Trying to fix the installation part of all pip modules at least.