### PR TITLE
Don't run git against dubious-ownership repo

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -129,12 +129,14 @@ def check_call(args):
 
 
 def get_manifest_git_checkout(manifest: t.Union[Path, str]) -> str:
-    manifest_dir = os.path.dirname(manifest)
-    output = subprocess.check_output(
-        ["git", "rev-parse", "--show-toplevel"],
-        cwd=manifest_dir,
-    )
-    return output.decode("utf-8").strip()
+    # Can't use git rev-parse --show-toplevel because of a chicken-and-egg problem: we
+    # need to find the checkout directory so that we can mark it as safe so that we can
+    # use git against it.
+    for directory in Path(manifest).parents:
+        if os.path.exists(directory / ".git"):
+            return str(directory)
+
+    raise FileNotFoundError(f"Cannot find git checkout for {manifest}")
 
 
 def ensure_git_safe_directory(checkout: t.Union[Path, str]):


### PR DESCRIPTION
(Initially I just reverted 7d6496d2b71f1b970cee3a5574d23af1155ca6ce but I think this is better.)

Modern git refuses to operate against a repo owned by a different
user. This happens in a GitHub action because the 'checkout' action
checks out the repo as UID 1001 but this app's container image runs as
UID 0.

We attempt to detect this "dubious ownership" situation and mark the
repo as safe, subverting the check. Since
7d6496d2b71f1b970cee3a5574d23af1155ca6ce we attempt to handle the case
where the manifest is not in the root of the git checkout. However,
using `git rev-parse --show-toplevel` in this situation does not work
because git considers the repo to have dubious ownership (which is what
we are trying to solve).

Instead, walk the ancestors of the manifest path, looking for a `.git`
file. (It need not be a directory: working copies created with `git
worktree` have a text file at `.git`, whose contents describe where the
main checkout is.)

Kludgy but it just might work.

Fixes https://github.com/flathub/flatpak-external-data-checker/issues/395
