### PR TITLE
Add support for max_line_length (EditorConfig)

### DIFF
--- a/src/lib/utils.py
+++ b/src/lib/utils.py
@@ -548,13 +548,11 @@ def dump_manifest(contents: t.Dict, manifest_path: t.Union[Path, str]):
         indent = 4
 
     # Determine max line length preference
-    max_line_length: t.Optional[int]
-    if "max_line_length" in conf:
+    if max_line_length := conf.get("max_line_length"):
         try:
-            max_line_length = int(conf.get("max_line_length"))
-            _yaml.width = max_line_length  # type: ignore # See https://sourceforge.net/p/ruamel-yaml/tickets/322/
+            _yaml.width = int(max_line_length)  # type: ignore # See https://sourceforge.net/p/ruamel-yaml/tickets/322/
         except ValueError:
-            log.error("max_line_length EditorConfig variable is not valid")
+            log.warning("Ignoring invalid max_line_length %r", max_line_length)
 
     # Determine trailing newline preference
     newline: t.Optional[bool]

--- a/src/lib/utils.py
+++ b/src/lib/utils.py
@@ -548,6 +548,7 @@ def dump_manifest(contents: t.Dict, manifest_path: t.Union[Path, str]):
         indent = 4
 
     # Determine max line length preference
+    max_line_length: t.Optional[int]
     if "max_line_length" in conf:
         try:
             max_line_length = int(conf.get("max_line_length"))

--- a/src/lib/utils.py
+++ b/src/lib/utils.py
@@ -552,7 +552,7 @@ def dump_manifest(contents: t.Dict, manifest_path: t.Union[Path, str]):
     if "max_line_length" in conf:
         try:
             max_line_length = int(conf.get("max_line_length"))
-            _yaml.width = max_line_length # type: ignore # See https://sourceforge.net/p/ruamel-yaml/tickets/322/
+            _yaml.width = max_line_length  # type: ignore # See https://sourceforge.net/p/ruamel-yaml/tickets/322/
         except ValueError:
             log.error("max_line_length EditorConfig variable is not valid")
 

--- a/src/lib/utils.py
+++ b/src/lib/utils.py
@@ -552,7 +552,7 @@ def dump_manifest(contents: t.Dict, manifest_path: t.Union[Path, str]):
     if "max_line_length" in conf:
         try:
             max_line_length = int(conf.get("max_line_length"))
-            _yaml.width = max_line_length
+            _yaml.width = max_line_length # type: ignore # See https://sourceforge.net/p/ruamel-yaml/tickets/322/
         except ValueError:
             log.error("max_line_length EditorConfig variable is not valid")
 

--- a/src/lib/utils.py
+++ b/src/lib/utils.py
@@ -547,6 +547,14 @@ def dump_manifest(contents: t.Dict, manifest_path: t.Union[Path, str]):
     else:
         indent = 4
 
+    # Determine max line length preference
+    if "max_line_length" in conf:
+        try:
+            max_line_length = int(conf.get("max_line_length"))
+            _yaml.width = max_line_length
+        except ValueError:
+            log.error("max_line_length EditorConfig variable is not valid")
+
     # Determine trailing newline preference
     newline: t.Optional[bool]
     if "insert_final_newline" in conf:


### PR DESCRIPTION
This PR adds support for the `max_line_length` following the [EditorConfig spec](https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties#supported-by-a-limited-number-of-editors). 
Directly follows #280 and linked to a recent PR in a repo I manage https://github.com/flathub/io.github.everestapi.Olympus/pull/2.

Fixes #280.