### PR TITLE
htmlchecker: allow specifying error handling on encoding error

### DIFF
--- a/src/checkers/htmlchecker.py
+++ b/src/checkers/htmlchecker.py
@@ -117,7 +117,9 @@ class HTMLChecker(Checker):
             encoding = "utf-8"
         return encoding
 
-    async def _get_text(self, url: t.Union[URL, str], encoding_error:str="strict") -> str:
+    async def _get_text(
+        self, url: t.Union[URL, str], encoding_error: str = "strict"
+    ) -> str:
         try:
             async with self.session.get(url) as response:
                 encoding = await self._get_encoding(response)


### PR DESCRIPTION
I need to fetch a binary encoded file, which contains the update name. The file is binary and just contains some readable strings. The problem is, that it already fails with `Error querying for new versions: 'utf-8' codec can't decode bytes in position` thus I am not able to apply any regexes on it. Now I can set an attribute called `encoding-error` to `ignore`. This is kinda hacky.

I am using the following checker code which now just works fine (tested it):
```
        x-checker-data:
          type: html
          url: http://versions.teamspeak.com/ts3-client-2
          version-pattern: "\u0006stable\u0010.*3\\.(\\d+\\.\\d+)\u0012"
          encoding-error: ignore
          url-template: https://files.teamspeak-services.com/releases/client/3.$version/TeamSpeak3-Client-linux_amd64-3.$version.run
```