### PR TITLE
Run flake8 on CI

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,3 +3,7 @@
 # <https://github.com/python/black#line-length>, defaults to 88, based on some
 # empirical research on reducing annoying line wrapping on real source code.
 max-line-length = 88
+
+# Black disagrees with some rules.
+# E203 - Whitespace before ':'
+extend-ignore = E203

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -37,6 +37,10 @@ jobs:
         run: |
           python3 -m black --check --diff .
 
+      - name: Run flake8
+        run: |
+          python3 -m flake8
+
   check-typing:
     name: Static type check
     runs-on: ubuntu-latest

--- a/dependencies.apt.txt
+++ b/dependencies.apt.txt
@@ -10,6 +10,7 @@ python3-brotli
 python3-cairo
 python3-chardet
 python3-editorconfig
+python3-flake8
 python3-gi
 python3-github
 python3-jsonschema

--- a/src/checkers/debianrepochecker.py
+++ b/src/checkers/debianrepochecker.py
@@ -163,9 +163,10 @@ class DebianRepoChecker(Checker):
 
                 new_version = ExternalFile(
                     url=candidate.uri,
-                    # FIXME: apt.package.Version.{md5,sha1,sha256} can raise an exception
-                    # if given hash isn't set, while sha512 isn't accessible at all.
-                    # Raw hashes are handy, but accessible only through protected property.
+                    # FIXME: apt.package.Version.{md5,sha1,sha256} can raise an
+                    # exception if given hash isn't set, while sha512 isn't accessible
+                    # at all. Raw hashes are handy, but accessible only through
+                    # protected property.
                     checksum=read_deb_hashes(candidate._records.hashes),
                     size=candidate.size,
                     version=candidate.version,
@@ -180,10 +181,10 @@ class DebianRepoChecker(Checker):
         return arches.get(arch, arch)
 
     async def _get_timestamp_for_candidate(self, candidate: apt.Version):
-        # TODO: fetch package, parse changelog, get the date from there.
-        # python-apt can fetch changelogs from Debian and Ubuntu's changelog
-        # server, but most packages this checker will be used for are not from these repos.
-        # We'd have to open-code it.
+        # TODO: fetch package, parse changelog, get the date from there. python-apt can
+        # fetch changelogs from Debian and Ubuntu's changelog server, but most packages
+        # this checker will be used for are not from these repos. We'd have to open-code
+        # it.
         # https://salsa.debian.org/apt-team/python-apt/blob/master/apt/package.py#L1245-1417
         assert candidate.uri
         return await get_timestamp_from_url(candidate.uri, self.session)

--- a/src/checkers/gitchecker.py
+++ b/src/checkers/gitchecker.py
@@ -141,7 +141,8 @@ class GitChecker(Checker):
             latest_tag = sorted_tags[-1]
         except IndexError as err:
             raise CheckerQueryError(
-                f"{external_data.current_version.url} has no tags matching '{tag_pattern}'"
+                f"{external_data.current_version.url} has no tags matching "
+                f"'{tag_pattern}'"
             ) from err
 
         new_version = ExternalGitRef(

--- a/src/checkers/gnomechecker.py
+++ b/src/checkers/gnomechecker.py
@@ -60,7 +60,8 @@ class GNOMEChecker(Checker):
         proj_url = GNOME_MIRROR / "sources" / project_name
         try:
             async with self.session.get(proj_url / "cache.json") as cache_resp:
-                # Some mirrors may sand invalid content-type; don't require it to be application/json
+                # Some mirrors may sand invalid content-type; don't require it to be
+                # application/json
                 cache_json = await cache_resp.json(content_type=None)
         except NETWORK_ERRORS as err:
             raise CheckerQueryError from err

--- a/src/checkers/htmlchecker.py
+++ b/src/checkers/htmlchecker.py
@@ -120,8 +120,9 @@ class HTMLChecker(Checker):
         try:
             async with self.session.get(url) as response:
                 encoding = await self._get_encoding(response)
-                # We use streaming decoding in order to get decode error and abort the check
-                # as early as possible, without preloading the whole raw contents into memory
+                # We use streaming decoding in order to get decode error and abort the
+                # check as early as possible, without preloading the whole raw contents
+                # into memory
                 decoder_cls = codecs.getincrementaldecoder(encoding)
                 decoder = decoder_cls(errors="strict")
                 with io.StringIO() as buf:
@@ -184,8 +185,9 @@ class HTMLChecker(Checker):
                 )
 
             try:
-                # NOTE Returning last match when sort is requested and first match otherwise
-                # doesn't seem sensible, but we need to retain backward compatibility
+                # NOTE Returning last match when sort is requested and first match
+                # otherwise doesn't seem sensible, but we need to retain backward
+                # compatibility
                 result = matches[-1 if sort_matches else 0]
             except IndexError as err:
                 raise CheckerQueryError(

--- a/src/lib/externaldata.py
+++ b/src/lib/externaldata.py
@@ -129,9 +129,10 @@ class BuilderSource(abc.ABC):
     checker_data: t.Dict[str, t.Any]
     module: t.Optional[BuilderModule]
     parent: t.Optional[BuilderSource] = dataclasses.field(init=False, default=None)
-    # fmt: off
-    checked: asyncio.Event = dataclasses.field(init=False, default_factory=asyncio.Event)
-    # fmt: on
+    checked: asyncio.Event = dataclasses.field(
+        init=False,
+        default_factory=asyncio.Event,
+    )
 
     @classmethod
     def __init_subclass__(cls, *args, **kwargs):

--- a/src/lib/utils.py
+++ b/src/lib/utils.py
@@ -222,8 +222,7 @@ class FallbackVersion(t.NamedTuple):
 
 
 class _SupportsComparison(t.Protocol):
-    def __lt__(self, other: t.Any) -> bool:
-        ...
+    def __lt__(self, other: t.Any) -> bool: ...
 
 
 _VersionedObj = t.TypeVar("_VersionedObj")

--- a/src/lib/utils.py
+++ b/src/lib/utils.py
@@ -160,11 +160,13 @@ async def get_extra_data_info_from_url(
         async for chunk in response.content.iter_chunked(HTTP_CHUNK_SIZE):
             if first_chunk:
                 first_chunk = False
-                # determine content type from magic number since http header may be wrong
+                # determine content type from magic number since http header may be
+                # wrong
                 actual_content_type = magic.from_buffer(chunk, mime=True)
                 if content_type_rejected(actual_content_type):
                     raise CheckerFetchError(
-                        f"Wrong content type '{actual_content_type}' received from '{url}'"
+                        f"Wrong content type '{actual_content_type}' received "
+                        f"from '{url}'"
                     )
 
             checksum.update(chunk)
@@ -429,7 +431,7 @@ async def git_ls_remote(url: str) -> t.Dict[str, str]:
         raise CheckerQueryError("Listing Git remote failed") from err
     git_stdout = git_stdout_raw.decode()
 
-    return {r: c for c, r in (l.split() for l in git_stdout.splitlines())}
+    return {r: c for c, r in (line.split() for line in git_stdout.splitlines())}
 
 
 async def extract_appimage_version(appimg_io: t.IO):
@@ -549,7 +551,8 @@ def dump_manifest(contents: t.Dict, manifest_path: t.Union[Path, str]):
     # Determine max line length preference
     if max_line_length := conf.get("max_line_length"):
         try:
-            _yaml.width = int(max_line_length)  # type: ignore # See https://sourceforge.net/p/ruamel-yaml/tickets/322/
+            # See https://sourceforge.net/p/ruamel-yaml/tickets/322/
+            _yaml.width = int(max_line_length)  # type: ignore
         except ValueError:
             log.warning("Ignoring invalid max_line_length %r", max_line_length)
 

--- a/src/main.py
+++ b/src/main.py
@@ -435,9 +435,13 @@ def parse_cli_args(cli_args=None):
     )
     parser.add_argument(
         "--require-important-update",
-        help="Require an update to at least one source with is-important or is-main-source to save changes to the manifest. "
-        "If no instances of is-important or is-main-source are found, assume normal behaviour and always save changes to the manifest. "
-        "This is useful to avoid PRs generated to update a singular unimportant source.",
+        help=(
+            "Require an update to at least one source with is-important or "
+            "is-main-source to save changes to the manifest. If no instances of "
+            "is-important or is-main-source are found, assume normal behaviour and "
+            "always save changes to the manifest. This is useful to avoid PRs "
+            "generated to update a singular unimportant source."
+        ),
         action="store_true",
     )
 

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -510,10 +510,10 @@ class ManifestChecker:
             log.debug("Version didn't change, not adding release")
 
     def update_manifests(self) -> t.List[str]:
-        """
-        Updates references to external data in manifests.
-        If require_important_update is True, only update the manifest
-        if at least one source with IMPORTANT_SRC_PROP or MAIN_SRC_PROP received an update.
+        """Updates references to external data in manifests.
+
+        If require_important_update is True, only update the manifest if at least one
+        source with IMPORTANT_SRC_PROP or MAIN_SRC_PROP received an update.
         """
         # We want a list, without duplicates; Python provides an
         # insertion-order-preserving dictionary so we use that.
@@ -526,7 +526,7 @@ class ManifestChecker:
             for data in self.get_external_data():
                 important = data.checker_data.get(IMPORTANT_SRC_PROP)
                 main = data.checker_data.get(MAIN_SRC_PROP)
-                if important or (main and important != False):
+                if important or (main and important is not False):
                     log.debug("Found an important source: %s", data)
 
                     found_important_update = data.has_version_changed

--- a/tests/org.chromium.Chromium.yaml
+++ b/tests/org.chromium.Chromium.yaml
@@ -3,15 +3,15 @@ modules:
   - name: chromium
     sources:
       - type: archive
-        url: https://commondatastorage.googleapis.com/chromium-browser-official/chromium-90.0.4430.212.tar.xz
-        sha256: abe11d0cb1ff21278aad2eec1a1e279d59176b15331804d7df1807446786d59e
+        url: https://commondatastorage.googleapis.com/chromium-browser-official/chromium-100.0.4845.0.tar.xz
+        sha256: a68d31f77a6b7700a5161d82f5932c2822f85f7ae68ad51be3d3cf689a3fe2b0
         x-checker-data:
           type: chromium
           component: chromium
           is-main-source: true
       - type: archive
-        url: https://commondatastorage.googleapis.com/chromium-browser-clang/Linux_x64/clang-llvmorg-13-init-1559-g01b87444-3.tgz
-        sha256: 676448e180fb060d3983f24476a2136eac83c6011c600117686035634a2bbe26
+        url: https://commondatastorage.googleapis.com/chromium-browser-clang/Linux_x64/clang-libs-llvmorg-14-init-12246-g7787a8f1-2.tgz
+        sha256: cf6b516a4e410d79439a150927fc8b450b325e2a6349395ae153c9d2dd6c6ed2
         x-checker-data:
           type: chromium
           component: llvm-prebuilt

--- a/tests/test_anityachecker.py
+++ b/tests/test_anityachecker.py
@@ -25,7 +25,7 @@ class TestAnityaChecker(unittest.IsolatedAsyncioTestCase):
                 self.assertIsInstance(data.new_version, ExternalFile)
                 self.assertRegex(
                     data.new_version.url,
-                    r"^https://download.gnome.org/sources/glib-networking/\d+.\d+/glib-networking-[\d.]+.tar.xz$",
+                    r"^https://download.gnome.org/sources/glib-networking/\d+.\d+/glib-networking-[\d.]+.tar.xz$",  # noqa: E501
                 )
                 self.assertIsNotNone(data.new_version.version)
                 self.assertGreater(
@@ -38,7 +38,7 @@ class TestAnityaChecker(unittest.IsolatedAsyncioTestCase):
                 self.assertNotEqual(
                     data.new_version.checksum,
                     MultiDigest(
-                        sha256="1f185aaef094123f8e25d8fa55661b3fd71020163a0174adb35a37685cda613b",
+                        sha256="1f185aaef094123f8e25d8fa55661b3fd71020163a0174adb35a37685cda613b",  # noqa: E501
                     ),
                 )
             elif data.filename == "boost_1_74_0.tar.bz2":
@@ -46,7 +46,7 @@ class TestAnityaChecker(unittest.IsolatedAsyncioTestCase):
                 self.assertIsInstance(data.new_version, ExternalFile)
                 self.assertRegex(
                     data.new_version.url,
-                    r"^https://boostorg\.jfrog\.io/artifactory/main/release/[\d.]+/source/boost_[\d]+_[\d]+_[\d]+.tar.bz2$",
+                    r"^https://boostorg\.jfrog\.io/artifactory/main/release/[\d.]+/source/boost_[\d]+_[\d]+_[\d]+.tar.bz2$",  # noqa: E501
                 )
                 self.assertIsNotNone(data.new_version.version)
                 self.assertGreater(
@@ -59,7 +59,7 @@ class TestAnityaChecker(unittest.IsolatedAsyncioTestCase):
                 self.assertNotEqual(
                     data.new_version.checksum,
                     MultiDigest(
-                        sha256="83bfc1507731a0906e387fc28b7ef5417d591429e51e788417fe9ff025e116b1"
+                        sha256="83bfc1507731a0906e387fc28b7ef5417d591429e51e788417fe9ff025e116b1"  # noqa: E501
                     ),
                 )
             elif data.filename == "flatpak-1.8.2.tar.xz":
@@ -67,7 +67,7 @@ class TestAnityaChecker(unittest.IsolatedAsyncioTestCase):
                 self.assertIsInstance(data.new_version, ExternalFile)
                 self.assertRegex(
                     data.new_version.url,
-                    r"^https://github.com/flatpak/flatpak/releases/download/[\w\d.]+/flatpak-[\w\d.]+.tar.xz$",
+                    r"^https://github.com/flatpak/flatpak/releases/download/[\w\d.]+/flatpak-[\w\d.]+.tar.xz$",  # noqa: E501
                 )
                 self.assertIsNotNone(data.new_version.version)
                 self.assertEqual(
@@ -80,7 +80,7 @@ class TestAnityaChecker(unittest.IsolatedAsyncioTestCase):
                 self.assertNotEqual(
                     data.new_version.checksum,
                     MultiDigest(
-                        sha256="7926625df7c2282a5ee1a8b3c317af53d40a663b1bc6b18a2dc8747e265085b0"
+                        sha256="7926625df7c2282a5ee1a8b3c317af53d40a663b1bc6b18a2dc8747e265085b0"  # noqa: E501
                     ),
                 )
             elif data.filename == "ostree.git":

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -466,7 +466,7 @@ size: {UpdateEverythingChecker.SIZE}
         self.assertEqual(
             relative_redirect.new_version.checksum,
             MultiDigest(
-                sha256="e4d67702da4eeeb2f15629b65bf6767c028a511839c14ed44d9f34479eaa2b94"
+                sha256="e4d67702da4eeeb2f15629b65bf6767c028a511839c14ed44d9f34479eaa2b94"  # noqa: E501
             ),
         )
         self.assertEqual(relative_redirect.new_version.size, 18)
@@ -615,10 +615,10 @@ modules:
           tag-pattern: ^(0.5.4)$
           sort-tags: false
           is-important: true
-          # since this is marked as the only important source, 
+          # since this is marked as the only important source,
           # but isn't getting updated, manifest should not be updated
 """.lstrip()
-        expected_new_contents = rf"""
+        expected_new_contents = r"""
 id: importantsource.com.virustotal.Uploader
 modules:
   - name: extra-cmake-modules
@@ -642,7 +642,7 @@ modules:
           tag-pattern: ^(0.5.4)$
           sort-tags: false
           is-important: true
-          # since this is marked as the only important source, 
+          # since this is marked as the only important source,
           # but isn't getting updated, manifest should not be updated
 """.lstrip()
         await self._test_update(
@@ -656,7 +656,8 @@ modules:
         )
 
     async def test_update_one_important_source_updated(self):
-        """With two sources, one of them being important and updated, so a manifest update should be made."""
+        """With two sources, one of them being important and updated, so a manifest
+        update should be made."""
         filename = "importantsource.com.virustotal.Uploader.yml"
         contents = rf"""
 id: importantsource.com.virustotal.Uploader
@@ -671,7 +672,7 @@ modules:
           type: git
           tag-pattern: ^(v5\.90\.0)$ # to ensure we only get this version
           is-important: true
-          # since this is marked as the only important source, 
+          # since this is marked as the only important source,
           # and is actually getting updated, manifest should be updated
   - name: vt-py
     sources:
@@ -698,7 +699,7 @@ modules:
           type: git
           tag-pattern: ^(v5\.90\.0)$ # to ensure we only get this version
           is-important: true
-          # since this is marked as the only important source, 
+          # since this is marked as the only important source,
           # and is actually getting updated, manifest should be updated
   - name: vt-py
     sources:
@@ -723,10 +724,9 @@ modules:
         )
 
     async def test_update_two_important_sources_first_updated(self):
-        """
-        With two important sources, the first getting updated,
-        so a manifest update should be made.
-        Tests for correct looping (i.e. once it finds a singular important source that's updated it should update the manifest).
+        """With two important sources, the first getting updated, so a manifest update
+        should be made. Tests for correct looping (i.e. once it finds a singular
+        important source that's updated it should update the manifest).
         """
         filename = "importantsource.com.virustotal.Uploader.yml"
         contents = r"""
@@ -742,7 +742,7 @@ modules:
           type: git
           tag-pattern: ^(v5\.90\.0)$ # to ensure we only get this version
           is-important: true
-          # since this is marked as a important source, 
+          # since this is marked as a important source,
           # and is getting updated, manifest should be updated
   - name: vt-py
     sources:
@@ -755,9 +755,10 @@ modules:
           type: git
           tag-pattern: ^(0.5.4)$
           sort-tags: false
-          is-important: true 
-          # this is marked as important and not being updated, 
-          # yet the manifest should still be updated since the previous source is important and getting an update.
+          is-important: true
+          # this is marked as important and not being updated,
+          # yet the manifest should still be updated since the previous source
+          # is important and getting an update.
 """.lstrip()
         expected_new_contents = rf"""
 id: importantsource.com.virustotal.Uploader
@@ -772,7 +773,7 @@ modules:
           type: git
           tag-pattern: ^(v5\.90\.0)$ # to ensure we only get this version
           is-important: true
-          # since this is marked as a important source, 
+          # since this is marked as a important source,
           # and is getting updated, manifest should be updated
   - name: vt-py
     sources:
@@ -786,8 +787,9 @@ modules:
           tag-pattern: ^(0.5.4)$
           sort-tags: false
           is-important: true
-          # this is marked as important and not being updated, 
-          # yet the manifest should still be updated since the previous source is important and getting an update.
+          # this is marked as important and not being updated,
+          # yet the manifest should still be updated since the previous source
+          # is important and getting an update.
 """.lstrip()
         await self._test_update(
             filename=filename,
@@ -803,9 +805,9 @@ modules:
         )
 
     async def test_update_two_important_sources_second_updated(self):
-        """With two important sources, the second getting updated,
-        so a manifest update should be made.
-        Tests for correct looping (i.e. once it finds a singular important source that's updated it should update the manifest).
+        """With two important sources, the second getting updated, so a manifest update
+        should be made. Tests for correct looping (i.e. once it finds a singular
+        important source that's updated it should update the manifest).
         """
         filename = "importantsource.com.virustotal.Uploader.yml"
         contents = rf"""
@@ -822,9 +824,10 @@ modules:
           type: git
           tag-pattern: ^(0.5.4)$
           sort-tags: false
-          is-important: true 
-          # this is marked as important and not being updated, 
-          # yet the manifest should still be updated since the next source is important and getting an update.
+          is-important: true
+          # this is marked as important and not being updated,
+          # yet the manifest should still be updated since the next source
+          # is important and getting an update.
   - name: extra-cmake-modules
     sources:
       - type: git
@@ -835,7 +838,7 @@ modules:
           type: git
           tag-pattern: ^(v5\.90\.0)$ # to ensure we only get this version
           is-important: true
-          # since this is marked as a important source, 
+          # since this is marked as a important source,
           # and is getting updated, manifest should be updated
 """.lstrip()
         expected_new_contents = rf"""
@@ -853,8 +856,9 @@ modules:
           tag-pattern: ^(0.5.4)$
           sort-tags: false
           is-important: true
-          # this is marked as important and not being updated, 
-          # yet the manifest should still be updated since the next source is important and getting an update.
+          # this is marked as important and not being updated,
+          # yet the manifest should still be updated since the next source
+          # is important and getting an update.
   - name: extra-cmake-modules
     sources:
       - type: git
@@ -865,7 +869,7 @@ modules:
           type: git
           tag-pattern: ^(v5\.90\.0)$ # to ensure we only get this version
           is-important: true
-          # since this is marked as a important source, 
+          # since this is marked as a important source,
           # and is getting updated, manifest should be updated
 """.lstrip()
         await self._test_update(
@@ -909,7 +913,7 @@ modules:
           # since this is marked as the only important/main source,
           # but isn't getting updated, manifest should not be updated
 """.lstrip()
-        expected_new_contents = rf"""
+        expected_new_contents = r"""
 id: importantsource.com.virustotal.Uploader
 modules:
   - name: extra-cmake-modules
@@ -1015,8 +1019,9 @@ modules:
         )
 
     async def test_require_important_source_disabled_no_important_source_updated(self):
-        """With two sources, one being important, but with require_important_source=false, so normal behaviour should occur.
-        Should disregard the fact that there is a singular important source not being updated
+        """With two sources, one being important, but with
+        require_important_source=false, so normal behaviour should occur. Should
+        disregard the fact that there is a singular important source not being updated
         """
         filename = "importantsource.com.virustotal.Uploader.yml"
         contents = r"""
@@ -1043,7 +1048,8 @@ modules:
           tag-pattern: ^(0.5.4)$
           sort-tags: false
           is-important: true
-          # manifest should still be updated since the require_important source is disabled
+          # manifest should still be updated since the require_important source
+          # is disabled
 """.lstrip()
         expected_new_contents = rf"""
 id: importantsource.com.virustotal.Uploader
@@ -1069,7 +1075,8 @@ modules:
           tag-pattern: ^(0.5.4)$
           sort-tags: false
           is-important: true
-          # manifest should still be updated since the require_important source is disabled
+          # manifest should still be updated since the require_important source
+          # is disabled
 """.lstrip()
         await self._test_update(
             filename=filename,
@@ -1085,7 +1092,8 @@ modules:
         )
 
     async def test_main_source_not_important(self):
-        """Normally the main source is considered important, however this can be overridden by setting is-important: false"""
+        """Normally the main source is considered important, however this can be
+        overridden by setting is-important: false"""
         filename = "importantsource.com.virustotal.Uploader.yml"
         contents = rf"""
 id: importantsource.com.virustotal.Uploader
@@ -1114,7 +1122,8 @@ modules:
           tag-pattern: ^(v5\.90\.0)$ # to ensure we only get this version
           is-main-source: true
           is-important: false
-          # since this is marked as the main source but is not important, it should not be updated
+          # since this is marked as the main source but is not important, it
+          # should not be updated
 """.lstrip()
         expected_new_contents = rf"""
 id: importantsource.com.virustotal.Uploader
@@ -1143,7 +1152,8 @@ modules:
           tag-pattern: ^(v5\.90\.0)$ # to ensure we only get this version
           is-main-source: true
           is-important: false
-          # since this is marked as the main source but is not important, it should not be updated
+          # since this is marked as the main source but is not important, it
+          # should not be updated
 """.lstrip()
         await self._test_update(
             filename=filename,

--- a/tests/test_chromiumchecker.py
+++ b/tests/test_chromiumchecker.py
@@ -29,7 +29,7 @@ class TestChromiumChecker(unittest.IsolatedAsyncioTestCase):
             self.assertIsNotNone(data.new_version)
             self.assertIsNotNone(data.new_version.version)
             self.assertGreater(
-                LooseVersion(data.new_version.version), LooseVersion("90.0.4430.212")
+                LooseVersion(data.new_version.version), LooseVersion("100.0.4845.0")
             )
 
             if isinstance(data, ExternalData):
@@ -44,7 +44,7 @@ class TestChromiumChecker(unittest.IsolatedAsyncioTestCase):
                     self.assertNotEqual(
                         data.new_version.checksum,
                         MultiDigest(
-                            sha256="abe11d0cb1ff21278aad2eec1a1e279d59176b15331804d7df1807446786d59e"
+                            sha256="a68d31f77a6b7700a5161d82f5932c2822f85f7ae68ad51be3d3cf689a3fe2b0"
                         ),
                     )
                 elif data.filename.startswith("clang-"):
@@ -55,7 +55,7 @@ class TestChromiumChecker(unittest.IsolatedAsyncioTestCase):
                     self.assertNotEqual(
                         data.new_version.checksum,
                         MultiDigest(
-                            sha256="676448e180fb060d3983f24476a2136eac83c6011c600117686035634a2bbe26"
+                            sha256="cf6b516a4e410d79439a150927fc8b450b325e2a6349395ae153c9d2dd6c6ed2"
                         ),
                     )
                 else:

--- a/tests/test_chromiumchecker.py
+++ b/tests/test_chromiumchecker.py
@@ -39,23 +39,23 @@ class TestChromiumChecker(unittest.IsolatedAsyncioTestCase):
                 if data.filename.startswith("chromium-"):
                     self.assertRegex(
                         data.new_version.url,
-                        r"^https://commondatastorage.googleapis.com/chromium-browser-official/chromium-[\d.]+\.tar\.xz$",
+                        r"^https://commondatastorage.googleapis.com/chromium-browser-official/chromium-[\d.]+\.tar\.xz$",  # noqa: E501
                     )
                     self.assertNotEqual(
                         data.new_version.checksum,
                         MultiDigest(
-                            sha256="a68d31f77a6b7700a5161d82f5932c2822f85f7ae68ad51be3d3cf689a3fe2b0"
+                            sha256="a68d31f77a6b7700a5161d82f5932c2822f85f7ae68ad51be3d3cf689a3fe2b0"  # noqa: E501
                         ),
                     )
                 elif data.filename.startswith("clang-"):
                     self.assertRegex(
                         data.new_version.url,
-                        r"^https://commondatastorage.googleapis.com/chromium-browser-clang/Linux_x64/clang-.*\.tgz$",
+                        r"^https://commondatastorage.googleapis.com/chromium-browser-clang/Linux_x64/clang-.*\.tgz$",  # noqa: E501
                     )
                     self.assertNotEqual(
                         data.new_version.checksum,
                         MultiDigest(
-                            sha256="cf6b516a4e410d79439a150927fc8b450b325e2a6349395ae153c9d2dd6c6ed2"
+                            sha256="cf6b516a4e410d79439a150927fc8b450b325e2a6349395ae153c9d2dd6c6ed2"  # noqa: E501
                         ),
                     )
                 else:

--- a/tests/test_debianrepochecker.py
+++ b/tests/test_debianrepochecker.py
@@ -37,12 +37,12 @@ class TestDebianRepoChecker(unittest.IsolatedAsyncioTestCase):
             if data.filename == "python-apt-source.tar.xz":
                 self.assertRegex(
                     data.new_version.url,
-                    r"http://deb.debian.org/debian/pool/main/p/python-apt/python-apt_(\d[\d\.-]+\d).tar.xz",
+                    r"http://deb.debian.org/debian/pool/main/p/python-apt/python-apt_(\d[\d\.-]+\d).tar.xz",  # noqa: E501
                 )
             elif data.filename == "apt-aarch64.deb":
                 self.assertRegex(
                     data.new_version.url,
-                    r"http://deb.debian.org/debian/pool/main/a/apt/apt_(\d[\d\.-]+\d)_arm64.deb",
+                    r"http://deb.debian.org/debian/pool/main/a/apt/apt_(\d[\d\.-]+\d)_arm64.deb",  # noqa: E501
                 )
             else:
                 self.fail(f"Unknown data {data.filename}")

--- a/tests/test_gnomechecker.py
+++ b/tests/test_gnomechecker.py
@@ -62,7 +62,7 @@ class TestGNOMEChecker(unittest.IsolatedAsyncioTestCase):
             self.assertNotEqual(
                 data.new_version.checksum,
                 MultiDigest(
-                    sha256="0000000000000000000000000000000000000000000000000000000000000000"
+                    sha256="0000000000000000000000000000000000000000000000000000000000000000"  # noqa: E501
                 ),
             )
             self.assertIsNotNone(data.new_version.version)

--- a/tests/test_htmlchecker.py
+++ b/tests/test_htmlchecker.py
@@ -37,7 +37,8 @@ from src.lib.errors import CheckerError
 class TestHTMLTools(unittest.IsolatedAsyncioTestCase):
     SAMPLES = {
         "utf-8": "🙋, 🌍!\n…"
-        # TODO we want to test other encodings, but httbin(go)/base64/ supports only utf-8
+        # TODO we want to test other encodings, but httbin(go)/base64/ supports only
+        # utf-8
     }
 
     async def asyncSetUp(self):
@@ -107,7 +108,7 @@ class TestHTMLChecker(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(
             data.new_version.checksum,
             MultiDigest(
-                sha256="d73b62f29eb98d850f16b76d759395180b860b613fbe1686b18eee99a6e3773f"
+                sha256="d73b62f29eb98d850f16b76d759395180b860b613fbe1686b18eee99a6e3773f"  # noqa: E501
             ),
         )
 
@@ -125,7 +126,7 @@ class TestHTMLChecker(unittest.IsolatedAsyncioTestCase):
         self.assertNotEqual(
             data.new_version.checksum,
             MultiDigest(
-                sha256="0000000000000000000000000000000000000000000000000000000000000000"
+                sha256="0000000000000000000000000000000000000000000000000000000000000000"  # noqa: E501
             ),
         )
 
@@ -143,7 +144,7 @@ class TestHTMLChecker(unittest.IsolatedAsyncioTestCase):
         self.assertNotEqual(
             data.new_version.checksum,
             MultiDigest(
-                sha256="0000000000000000000000000000000000000000000000000000000000000000"
+                sha256="0000000000000000000000000000000000000000000000000000000000000000"  # noqa: E501
             ),
         )
 
@@ -174,7 +175,7 @@ class TestHTMLChecker(unittest.IsolatedAsyncioTestCase):
             child.new_version.checksum,
             # curl https://httpbingo.org/response-headers?version=1.0.0 | sha256sum
             MultiDigest(
-                sha256="b7160b96668c66cdee4ec5b0115bc5a7a8d58cd86b3ff49473e1611947babda3"
+                sha256="b7160b96668c66cdee4ec5b0115bc5a7a8d58cd86b3ff49473e1611947babda3"  # noqa: E501
             ),
         )
         self.assertEqual(parent.new_version.checksum, child.new_version.checksum)

--- a/tests/test_jetbrainschecker.py
+++ b/tests/test_jetbrainschecker.py
@@ -31,7 +31,7 @@ class TestJetBrainsChecker(unittest.IsolatedAsyncioTestCase):
         self.assertNotEqual(
             data.new_version.checksum,
             MultiDigest(
-                sha256="0000000000000000000000000000000000000000000000000000000000000000"
+                sha256="0000000000000000000000000000000000000000000000000000000000000000"  # noqa: E501
             ),
         )
 

--- a/tests/test_jsonchecker.py
+++ b/tests/test_jsonchecker.py
@@ -26,7 +26,7 @@ class TestJSONChecker(unittest.IsolatedAsyncioTestCase):
                 self.assertNotEqual(data.current_version.url, data.new_version.url)
                 self.assertRegex(
                     data.new_version.url,
-                    r"^https://github.com/jqlang/jq/releases/download/jq-[0-9\.\w]+/jq-[0-9\.\w]+\.tar.gz$",
+                    r"^https://github.com/jqlang/jq/releases/download/jq-[0-9\.\w]+/jq-[0-9\.\w]+\.tar.gz$",  # noqa: E501
                 )
                 self.assertIsInstance(data.new_version.size, int)
                 self.assertGreater(data.new_version.size, 0)
@@ -35,7 +35,7 @@ class TestJSONChecker(unittest.IsolatedAsyncioTestCase):
                 self.assertNotEqual(
                     data.new_version.checksum,
                     MultiDigest(
-                        sha256="0000000000000000000000000000000000000000000000000000000000000000"
+                        sha256="0000000000000000000000000000000000000000000000000000000000000000"  # noqa: E501
                     ),
                 )
             elif data.filename == "jq-1.4.tarball.tar.gz":

--- a/tests/test_pypichecker.py
+++ b/tests/test_pypichecker.py
@@ -33,17 +33,17 @@ class TestPyPIChecker(unittest.IsolatedAsyncioTestCase):
             if data.filename == "setuptools-50.3.2-py3-none-any.whl":
                 self.assertRegex(
                     data.new_version.url,
-                    r"https://files.pythonhosted.org/packages/[a-f0-9/]+/setuptools-[\d\.]+-[\S\.]+-none-any.whl",
+                    r"https://files.pythonhosted.org/packages/[a-f0-9/]+/setuptools-[\d\.]+-[\S\.]+-none-any.whl",  # noqa: E501
                 )
             elif data.filename == "PyYAML-5.3.1.tar.gz":
                 self.assertRegex(
                     data.new_version.url,
-                    r"https://files.pythonhosted.org/packages/[a-f0-9/]+/PyYAML-[\d\.]+.(tar.(gz|xz|bz2)|zip)",
+                    r"https://files.pythonhosted.org/packages/[a-f0-9/]+/PyYAML-[\d\.]+.(tar.(gz|xz|bz2)|zip)",  # noqa: E501
                 )
             elif data.filename == "vdf-3.1-py2.py3-none-any.whl":
                 self.assertRegex(
                     data.new_version.url,
-                    r"https://files.pythonhosted.org/packages/[a-f0-9/]+/vdf-[\d\.]+-[\S\.]+-none-any.whl",
+                    r"https://files.pythonhosted.org/packages/[a-f0-9/]+/vdf-[\d\.]+-[\S\.]+-none-any.whl",  # noqa: E501
                 )
                 self.assertEqual(data.new_version.version, "3.2")
             elif data.filename == "Pillow-7.2.0.tar.gz":

--- a/tests/test_rpmrepochecker.py
+++ b/tests/test_rpmrepochecker.py
@@ -28,7 +28,7 @@ class TestRPMRepoChecker(unittest.IsolatedAsyncioTestCase):
             )
             self.assertRegex(
                 data.new_version.url,
-                r"https://packages\.microsoft\.com/yumrepos/.+?/code-.+\.{0}\.rpm".format(
+                r"https://packages\.microsoft\.com/yumrepos/.+?/code-.+\.{0}\.rpm".format(  # noqa: E501
                     data.arches[0]
                 ),
             )

--- a/tests/test_rustchecker.py
+++ b/tests/test_rustchecker.py
@@ -23,7 +23,7 @@ class TestRustChecker(unittest.IsolatedAsyncioTestCase):
         self.assertIsNotNone(data.new_version)
         self.assertRegex(
             data.new_version.url,
-            r"^https://static.rust-lang.org/dist/[\-\d]+/rust-nightly-x86_64-unknown-linux-gnu.tar.xz$",
+            r"^https://static.rust-lang.org/dist/[\-\d]+/rust-nightly-x86_64-unknown-linux-gnu.tar.xz$",  # noqa: E501
         )
         self.assertIsNone(data.new_version.size)
         self.assertIsNotNone(data.new_version.checksum)
@@ -31,7 +31,7 @@ class TestRustChecker(unittest.IsolatedAsyncioTestCase):
         self.assertNotEqual(
             data.new_version.checksum,
             MultiDigest(
-                sha256="24b4681187654778817652273a68a4d55f5090604cd14b1f1c3ff8785ad24b99"
+                sha256="24b4681187654778817652273a68a4d55f5090604cd14b1f1c3ff8785ad24b99"  # noqa: E501
             ),
         )
 

--- a/tests/test_snapcraftchecker.py
+++ b/tests/test_snapcraftchecker.py
@@ -22,7 +22,7 @@ class TestSnapctaftChecker(unittest.IsolatedAsyncioTestCase):
         self.assertIsNotNone(data.new_version)
         self.assertRegex(
             data.new_version.url,
-            r"^https://api\.snapcraft\.io/api/v1/snaps/download/[A-Za-z0-9]{32}_[0-9]+.snap$",
+            r"^https://api\.snapcraft\.io/api/v1/snaps/download/[A-Za-z0-9]{32}_[0-9]+.snap$",  # noqa: E501
         )
         self.assertIsInstance(data.new_version.size, int)
         self.assertGreater(data.new_version.size, 0)
@@ -31,7 +31,7 @@ class TestSnapctaftChecker(unittest.IsolatedAsyncioTestCase):
         self.assertNotEqual(
             data.new_version.checksum,
             MultiDigest(
-                sha256="0000000000000000000000000000000000000000000000000000000000000000"
+                sha256="0000000000000000000000000000000000000000000000000000000000000000"  # noqa: E501
             ),
         )
 

--- a/tests/test_urlchecker.py
+++ b/tests/test_urlchecker.py
@@ -27,7 +27,7 @@ class TestURLChecker(unittest.IsolatedAsyncioTestCase):
         self.assertNotEqual(
             data.new_version.checksum,
             MultiDigest(
-                sha256="0000000000000000000000000000000000000000000000000000000000000000"
+                sha256="0000000000000000000000000000000000000000000000000000000000000000"  # noqa: E501
             ),
         )
         self.assertIsNotNone(data.new_version.version)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -26,6 +26,7 @@ from contextlib import contextmanager
 import re
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from textwrap import dedent
 
 import aiohttp
 
@@ -64,7 +65,7 @@ class TestParseGitHubUrl(unittest.TestCase):
 class TestStripQuery(unittest.TestCase):
     def test_strip_query(self):
         url = "https://d11yldzmag5yn.cloudfront.net/prod/3.5.372466.0322/zoom_x86_64.tar.xz?_x_zm_rtaid=muDd1uOqSZ-xUScZF698QQ.1585134521724.21e5ab14908b2121f5ed53882df91cb9&_x_zm_rhtaid=732"  # noqa: E501
-        expected = "https://d11yldzmag5yn.cloudfront.net/prod/3.5.372466.0322/zoom_x86_64.tar.xz"
+        expected = "https://d11yldzmag5yn.cloudfront.net/prod/3.5.372466.0322/zoom_x86_64.tar.xz"  # noqa: E501
         self.assertEqual(strip_query(url), expected)
 
     def test_preserve_nice_query(self):
@@ -229,7 +230,7 @@ class TestDownload(unittest.IsolatedAsyncioTestCase):
 
     async def test_correct_content_type(self):
         await get_extra_data_info_from_url(
-            url=f"https://ftp.gnu.org/gnu/gzip/gzip-1.12.tar.gz",
+            url="https://ftp.gnu.org/gnu/gzip/gzip-1.12.tar.gz",
             session=self.http,
             content_type_deny=[re.compile(r"^application/x-fedc-test$")],
         )
@@ -252,57 +253,74 @@ class TestDownload(unittest.IsolatedAsyncioTestCase):
         # 2. As a result it is rejected
         with self.assertRaises(CheckerFetchError):
             await get_extra_data_info_from_url(
-                url=f"https://httpbingo.org/response-headers?Content-Type=application/gzip",
+                url="https://httpbingo.org/response-headers?Content-Type=application/gzip",  # noqa: E501
                 session=self.http,
                 content_type_deny=[re.compile(r"^application/json$")],
             )
 
 
 EDITORCONFIG_SAMPLE_DATA = {"first": 1, "second": [2, 3]}
-# fmt: off
 EDITORCONFIG_STYLES = [
-# 2-space with newline
-("""
-[*.json]
-indent_style = space
-indent_size = 2
-insert_final_newline = true
-""",
-# ---
-"""{
-  "first": 1,
-  "second": [
-    2,
-    3
-  ]
-}
-"""),
-# Tab without newline
-("""
-[*.json]
-indent_style = tab
-insert_final_newline = false
-""",
-# ---
-"""{
-	"first": 1,
-	"second": [
-		2,
-		3
-	]
-}"""),
-# No preference, default to 4-space without newline
-(None,
-# ---
-"""{
-    "first": 1,
-    "second": [
-        2,
-        3
-    ]
-}"""),
+    # 2-space with newline
+    (
+        dedent(
+            """\
+            [*.json]
+            indent_style = space
+            indent_size = 2
+            insert_final_newline = true
+            """
+        ),
+        # ---
+        dedent(
+            """\
+            {
+              "first": 1,
+              "second": [
+                2,
+                3
+              ]
+            }
+            """
+        ),
+    ),
+    # Tab without newline
+    (
+        dedent(
+            """\
+            [*.json]
+            indent_style = tab
+            insert_final_newline = false
+            """
+        ),
+        # ---
+        dedent(
+            """\
+            {
+            \t"first": 1,
+            \t"second": [
+            \t\t2,
+            \t\t3
+            \t]
+            }"""
+        ),
+    ),
+    # No preference, default to 4-space without newline
+    (
+        None,
+        # ---
+        dedent(
+            """\
+            {
+                "first": 1,
+                "second": [
+                    2,
+                    3
+                ]
+            }"""
+        ),
+    ),
 ]
-# fmt: on
 
 
 class TestDumpManifest(unittest.TestCase):


### PR DESCRIPTION
`black` only does formatting while `flake8` is a linter, so it's good to run both. In order to get there:

* Fix a failing test (I can split this out if preferred)
* Fix a recent black diff (this is also in #414)
* Fix all the existing flake8 warnings and errors
* Install and run flake8 from the formatting workflow job