### PR TITLE
Fix docker image in readme to work in FlatHub GitHub org

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ jobs:
         with:
           ref: ${{ matrix.branch }}
 
-      - uses: docker://ghcr.io/flathub-infra/flatpak-external-data-checker:latest
+      - uses: docker://ghcr.io/flathub/flatpak-external-data-checker:latest
         env:
           GIT_AUTHOR_NAME: Flatpak External Data Checker
           GIT_COMMITTER_NAME: Flatpak External Data Checker


### PR DESCRIPTION
Partially related is #416. The image in the readme for the github action is now allowed for repos. Thus this PR changes the image to the one under flathub/* which is allowed.