### PR TITLE
fixed the external data checker from stalling when git tag pattern is incorrect, this should fix the github actions run

### DIFF
--- a/src/checkers/__init__.py
+++ b/src/checkers/__init__.py
@@ -180,6 +180,29 @@ class Checker:
         except (KeyError, ValueError) as err:
             raise CheckerMetadataError("Error substituting template") from err
 
+    @classmethod
+    def _get_pattern(
+        cls,
+        checker_data: t.Dict,
+        pattern_name: str,
+        expected_groups: int = 1,
+    ) -> t.Optional[re.Pattern]:
+        try:
+            pattern_str = checker_data[pattern_name]
+        except KeyError:
+            return None
+
+        try:
+            pattern = re.compile(pattern_str)
+        except re.error as err:
+            raise CheckerMetadataError(f"Invalid regex '{pattern_str}'") from err
+        if pattern.groups != expected_groups:
+            raise CheckerMetadataError(
+                f"Pattern '{pattern.pattern}' contains {pattern.groups} group(s) "
+                f"instead of {expected_groups}"
+            )
+        return pattern
+
     async def _complete_digests(
         self, url: t.Union[str, URL], digests: MultiDigest
     ) -> MultiDigest:

--- a/src/checkers/htmlchecker.py
+++ b/src/checkers/htmlchecker.py
@@ -31,30 +31,11 @@ import semver
 
 from ..lib import NETWORK_ERRORS, OPERATORS_SCHEMA
 from ..lib.externaldata import ExternalBase, ExternalData
-from ..lib.errors import CheckerMetadataError, CheckerQueryError, CheckerFetchError
+from ..lib.errors import CheckerQueryError, CheckerFetchError
 from . import Checker
 from ..lib.utils import filter_versioned_items, FallbackVersion
 
 log = logging.getLogger(__name__)
-
-
-def _get_pattern(
-    checker_data: t.Dict, pattern_name: str, expected_groups: int = 1
-) -> t.Optional[re.Pattern]:
-    try:
-        pattern_str = checker_data[pattern_name]
-    except KeyError:
-        return None
-    try:
-        pattern = re.compile(pattern_str)
-    except re.error as err:
-        raise CheckerMetadataError(f"Invalid regex '{pattern_str}'") from err
-    if pattern.groups != expected_groups:
-        raise CheckerMetadataError(
-            f"Pattern '{pattern.pattern}' contains {pattern.groups} group(s) "
-            f"instead of {expected_groups}"
-        )
-    return pattern
 
 
 def _semantic_version(version: str) -> semver.VersionInfo:
@@ -157,8 +138,10 @@ class HTMLChecker(Checker):
             {f"parent_{k}": v for k, v in parent_json.items() if v is not None},
         )
 
-        combo_pattern = _get_pattern(external_data.checker_data, "pattern", 2)
-        version_pattern = _get_pattern(external_data.checker_data, "version-pattern", 1)
+        combo_pattern = self._get_pattern(external_data.checker_data, "pattern", 2)
+        version_pattern = self._get_pattern(
+            external_data.checker_data, "version-pattern", 1
+        )
         url_template = external_data.checker_data.get("url-template")
         sort_matches = external_data.checker_data.get("sort-matches", True)
         version_cls = _VERSION_SCHEMES[


### PR DESCRIPTION
I recently opened a related issue:
This closes https://github.com/flathub-infra/flatpak-external-data-checker/issues/418
In this issue I said, that I don't know how to fix this problem. However, I figured it out.