### PR TITLE
main: Handle git failing on invalid fallback email

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -197,7 +197,8 @@ def commit_changes(changes: t.List[str]) -> CommittedChanges:
         base_branch = None
 
     # Moved to detached HEAD
-    check_call(["git", "checkout", "HEAD@{0}"])
+    log.info("Switching to detached HEAD")
+    check_call(["git", "-c", "advice.detachedHead=false", "checkout", "HEAD@{0}"])
     check_call(["git", "commit", "-am", message])
 
     # Find a stable identifier for the contents of the tree, to avoid

--- a/src/main.py
+++ b/src/main.py
@@ -24,6 +24,7 @@
 
 import argparse
 import contextlib
+import getpass
 import json
 import logging
 import os
@@ -199,7 +200,22 @@ def commit_changes(changes: t.List[str]) -> CommittedChanges:
     # Moved to detached HEAD
     log.info("Switching to detached HEAD")
     check_call(["git", "-c", "advice.detachedHead=false", "checkout", "HEAD@{0}"])
-    check_call(["git", "commit", "-am", message])
+
+    try:
+        git_email = subprocess.check_output(
+            ["git", "config", "user.email"], encoding="utf-8"
+        ).strip()
+    except subprocess.CalledProcessError:
+        git_email = None
+        pass
+
+    if git_email is None:
+        git_email = getpass.getuser() + "@" + os.uname()[1]
+        assert git_email is not None
+        log.warning("No email configured for git. Falling back to default")
+        check_call(["git", "-c", f"user.email={git_email}", "commit", "-am", message])
+    else:
+        check_call(["git", "commit", "-am", message])
 
     # Find a stable identifier for the contents of the tree, to avoid
     # sending the same PR twice.


### PR DESCRIPTION
Updating the manifest from the x-checker flatpak with `--update` inside
the x-checker Flatpak causes the following error:

```
HEAD is now at b6053d8 test
Author identity unknown

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: unable to auto-detect email address (got 'bbhtt@fedora.(none)')
Traceback (most recent call last):
  File "/app/bin/flatpak-external-data-checker", line 30, in <module>
    main()
  File "/app/lib/fedc/src/main.py", line 504, in main
    outdated_num, errors_num, updated = asyncio.run(run_with_args(args))
                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/asyncio/runners.py", line 190, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/asyncio/base_events.py", line 654, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/app/lib/fedc/src/main.py", line 475, in run_with_args
    committed_changes = commit_changes(changes)
                        ^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/lib/fedc/src/main.py", line 201, in commit_changes
    check_call(["git", "commit", "-am", message])
  File "/app/lib/fedc/src/main.py", line 128, in check_call
    subprocess.check_call(args)
  File "/usr/lib/python3.11/subprocess.py", line 413, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['git', 'commit', '-am', 'Update PyQt6-6.4.1.tar.gz to 6.4.2']' returned non-zero exit status 128.
```

This is because git cannot find a configuration for `user.name` and
`user.email` as the config file might be outside of Flatpak's access
for example in (~/.config/git) which is not mounted to XDG_CONFIG_HOME
in the sandbox. In that case git tries to fallback to using pwd database
name [1] as `user.name` and hostname or mailname for `user.email` [2]

But the runtime ships neither of those so it generates a bogus `.(none)`
domain [3] and subsequently the git commit subprocess exits with error.

So generate our own email and commit with it on-the-fly to make sure
nothing gets written to any git config.

[1]: https://github.com/git/git/blob/c3ebe91b40c23a1b70dba36383a23016711d8bc0/ident.c#L505-L513
[2]: https://github.com/git/git/blob/c3ebe91b40c23a1b70dba36383a23016711d8bc0/ident.c#L157-L159
[3]: https://github.com/git/git/blob/c3ebe91b40c23a1b70dba36383a23016711d8bc0/ident.c#L135-L142