### PR TITLE
main: Set module names as title

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -177,15 +177,39 @@ class CommittedChanges(t.NamedTuple):
     base_branch: t.Optional[str]
 
 
+def commit_message(changes: t.List[str]) -> str:
+    assert len(changes) >= 1
+
+    if len(changes) == 1:
+        return changes[0]
+
+    module_names = list(dict.fromkeys(list(i.split(":", 1)[0] for i in changes)))
+    for i in reversed(range(2, len(module_names) + 1)):
+        xs = module_names[: i - 1]
+        y = module_names[i - 1]
+        zs = module_names[i:]
+
+        if zs:
+            tail = f" and {len(zs)} more modules"
+            xs.append(y)
+        else:
+            tail = f" and {y} modules"
+
+        subject = "Update " + ", ".join(xs) + tail
+        if len(subject) <= 70:
+            return subject
+
+    return f"Update {len(module_names)} modules"
+
+
 def commit_changes(changes: t.List[str]) -> CommittedChanges:
     log.info("Committing updates")
     body: t.Optional[str]
+    subject = commit_message(changes)
     if len(changes) > 1:
-        subject = "Update {} modules".format(len(changes))
         body = "\n".join(changes)
         message = subject + "\n\n" + body
     else:
-        subject = changes[0]
         body = None
         message = subject
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -74,7 +74,7 @@ class TestEntrypoint(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(await main.run_with_args(args1), (2, 0, True))
 
         commit_data = self._get_commit_data()
-        self.assertEqual(commit_data["subject"], "Update 2 modules")
+        self.assertEqual(commit_data["subject"], "Update libXaw and xterm modules")
         self.assertEqual(commit_data["author_name"], "Test Runner")
         self.assertEqual(commit_data["author_email"], "test@localhost")
         self.assertEqual(commit_data["committer_name"], "Test Runner")
@@ -95,7 +95,7 @@ class TestEntrypoint(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(await main.run_with_args(args1), (2, 0, True))
 
         commit_data = self._get_commit_data()
-        self.assertEqual(commit_data["subject"], "Update 2 modules")
+        self.assertEqual(commit_data["subject"], "Update libXaw and xterm modules")
         self.assertEqual(commit_data["author_name"], "Some Guy")
         self.assertEqual(commit_data["author_email"], "someguy@localhost")
         self.assertEqual(commit_data["committer_name"], "Test Runner")


### PR DESCRIPTION
Choose the "best" title with most module names while making sure it does
not cross 70 characters. The limit is to prevent too much verbosity in
commit messages and PR titles when a large set of modules are getting
updated.

If it crosses 70 characters, start deducting module names and add the
number of remaining updated modules.