### PR TITLE
gnomechecker: Don't consider 3.odd unstable

### DIFF
--- a/src/checkers/gnomechecker.py
+++ b/src/checkers/gnomechecker.py
@@ -32,8 +32,6 @@ def _is_stable(version: str) -> bool:
     major, minor = ver_list[:2]
     if set(ver_list[1:]) & {"alpha", "beta", "rc"}:
         return False
-    if int(major) > 0 and int(major) < 40 and len(ver_list) > 2:
-        return (int(minor) % 2) == 0
     # XXX If we didn't see any indication that the version is a prerelease,
     # assume it's a normal (stable) release
     return True


### PR DESCRIPTION
There is only a handful of modules using the older version scheming.

The version scheme consisted declaring a release with numbering 3.x stable if 3 was even and odd otherwise. This versioning scheme was dropped by most modules around GNOME 40.

For context, this causes multiple false positives with modules like tracker who have a major version equal to three but do not follow the old numbering scheme.

cc @fosero, @ebassi.