### PR TITLE
Document changing host for `rotating-url` and assume same version based only on checksum and file size

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,17 @@ The version number for the latest version can be detected in two ways:
   URL for the latest version, and the first match group is taken to be the
   version. (This follows the convention used by
   [`debian/watch`](https://wiki.debian.org/debian/watch) files.)
+* If downloads come from load-balanced URLs, the `"pattern"` regex must
+  match all URL variants otherwise identical versions may be treated as
+  updates. Eg.
+
+```json
+"x-checker-data": {
+  "type": "rotating-url",
+  "url": "http://example.com/last-version",
+  "pattern": "https://(?:dl|stable.dl\\d).example.com/foo-v([0-9.]+).tar.gz"
+}
+```
 
 Some upstream vendors may add unwanted GET query parameters to
 the download URL, such as identifiers for counting unique downloads.

--- a/src/checkers/urlchecker.py
+++ b/src/checkers/urlchecker.py
@@ -61,6 +61,24 @@ def extract_version(checker_data, url):
     return m.group(1)
 
 
+def is_same_version(checker_data, current_url, new_version):
+    if new_version is None:
+        return False
+
+    if new_version.version is None:
+        # No pattern given or failed parsing the new version
+        # so fallback to checking if URL matches
+        return current_url == new_version.url
+
+    current_version_string = extract_version(checker_data, current_url)
+    if current_version_string is None:
+        # If the pattern failed to apply to the old/current fallback
+        # again to checking if URL matches
+        return current_url == new_version.url
+
+    return current_version_string == new_version.version
+
+
 class URLChecker(Checker):
     PRIORITY = 99
     CHECKER_DATA_TYPE = "rotating-url"
@@ -146,9 +164,10 @@ class URLChecker(Checker):
         if not is_rotating:
             new_version = new_version._replace(url=url)  # pylint: disable=no-member
 
+        same_version = is_same_version(
+            external_data.checker_data, external_data.current_version.url, new_version
+        )
         external_data.set_new_version(
             new_version,
-            is_update=(
-                is_rotating and external_data.current_version.url != new_version.url
-            ),
+            is_update=is_rotating and not same_version,
         )

--- a/src/lib/externaldata.py
+++ b/src/lib/externaldata.py
@@ -319,10 +319,8 @@ class ExternalFile(ExternalState):
     def matches(self, other: ExternalFile):
         for i in (self, other):
             assert i.checksum is None or isinstance(i.checksum, MultiDigest), i.checksum
-        return (
-            self.url == other.url
-            and self.checksum == other.checksum
-            and (self.size is None or other.size is None or self.size == other.size)
+        return self.checksum == other.checksum and (
+            self.size is None or other.size is None or self.size == other.size
         )
 
     def is_same_version(self, other: ExternalFile):


### PR DESCRIPTION
# Description

Hey there,

## Motivation

The Flatpak projects for [Discord](https://github.com/flathub/com.discordapp.Discord/pull/444/files), [War Thunder](https://github.com/flathub/net.gaijin.WarThunder/pull/236/files) seen multiple PR for the same version number, because of a changed URL. This behavior could indicate load-balancing. The hash and version number stays the same, which you can see in the referenced PRs.

```diff
-        url: https://cdnnow-distr.gaijinent.com/wt_launcher_linux_1.0.3.15.tar.gz
+        url: https://aws-yup-distr-02.gaijinent.com/wt_launcher_linux_1.0.3.15.tar.gz
         sha256: c89e4a41185bfaab634a978a0eac9752c42fea1afb6c094692063ceb40760e15
```

## Changes

### Documentation 

in this PR I added some documentation on how to use non-capturing groups to allow the pattern to match despite the changing host. The use of non-capturing groups then doesn't cause conflicts with the version extraction of the first capturing version group.

### `urlchecker`

I adjusted the `is_update` parameter to compare the version numbers if they could be extracted to reflect that it's still the same version. Nevertheless, this change doesn't stop this project from reporting a new update without the changes below.

### `externaldata`

I dropped the URL comparison in `ExternalFile`s to rely only on checksum and file size to report identical files. Without this change `matches` and `is_same_version` both uses the URL and therefore report `False` and program flow goes into `self.new_version = new_version` and so reports `... got new version` although the version is still up to date.

https://github.com/flathub-infra/flatpak-external-data-checker/blob/a01c7754dd04fc0ed5671e909e705fe74448870a/src/lib/externaldata.py#L284-L290

### Alternatives

The changes mentioned will affect all sources that uses `ExternalFile` to rely only on checksum and size. An alternative would be to modify `ExternalFile.is_same_version` which uses url compares too, which seems to be a better based on the name. **However, this wouldn't work for `AppImage`s, because then we would need to download the old/current version again to extract that version number.**

# Testing 

I used Discord's project for validation with the following changes:
```json
[...]
                    "x-checker-data": {
[...]
                        "pattern": "https://(?:dl|stable.dl\\d).discordapp.net/apps/linux/([0-9.]+)/discord-([0-9.]+).tar.gz"
                    }
[...]
```

# Related

* #438
* #373

Fixes #438