### PR TITLE
chromiumchecker: Switch prebuilt Clang url to use .tar.xz

### DIFF
--- a/src/checkers/chromiumchecker.py
+++ b/src/checkers/chromiumchecker.py
@@ -129,7 +129,7 @@ class LLVMPrebuiltComponent(LLVMComponent):
 
     _PREBUILT_URL_FORMAT = (
         "https://commondatastorage.googleapis.com"
-        "/chromium-browser-clang/Linux_x64/clang-{revision}-{sub_revision}.tgz"
+        "/chromium-browser-clang/Linux_x64/clang-{revision}-{sub_revision}.tar.xz"
     )
 
     async def check(self) -> None:

--- a/tests/test_chromiumchecker.py
+++ b/tests/test_chromiumchecker.py
@@ -50,7 +50,7 @@ class TestChromiumChecker(unittest.IsolatedAsyncioTestCase):
                 elif data.filename.startswith("clang-"):
                     self.assertRegex(
                         data.new_version.url,
-                        r"^https://commondatastorage.googleapis.com/chromium-browser-clang/Linux_x64/clang-.*\.tgz$",  # noqa: E501
+                        r"^https://commondatastorage.googleapis.com/chromium-browser-clang/Linux_x64/clang-.*\.tar\.xz$",  # noqa: E501
                     )
                     self.assertNotEqual(
                         data.new_version.checksum,


### PR DESCRIPTION
The gzip archives aren't produced anymore:

https://chromium-review.googlesource.com/c/chromium/src/+/5544198