### PR TITLE
chromiumchecker: Use Gentoo-hosted tarball mirrors on 404

### DIFF
--- a/tests/test_chromiumchecker.py
+++ b/tests/test_chromiumchecker.py
@@ -39,7 +39,7 @@ class TestChromiumChecker(unittest.IsolatedAsyncioTestCase):
                 if data.filename.startswith("chromium-"):
                     self.assertRegex(
                         data.new_version.url,
-                        r"^https://commondatastorage.googleapis.com/chromium-browser-official/chromium-[\d.]+\.tar\.xz$",  # noqa: E501
+                        r"^https://(commondatastorage.googleapis.com/chromium-browser-official|chromium-tarballs.distfiles.gentoo.org)/chromium-[\d.]+\.tar\.xz$",  # noqa: E501
                     )
                     self.assertNotEqual(
                         data.new_version.checksum,

--- a/tests/test_pypichecker.py
+++ b/tests/test_pypichecker.py
@@ -38,7 +38,7 @@ class TestPyPIChecker(unittest.IsolatedAsyncioTestCase):
             elif data.filename == "PyYAML-5.3.1.tar.gz":
                 self.assertRegex(
                     data.new_version.url,
-                    r"https://files.pythonhosted.org/packages/[a-f0-9/]+/PyYAML-[\d\.]+.(tar.(gz|xz|bz2)|zip)",  # noqa: E501
+                    r"https://files.pythonhosted.org/packages/[a-f0-9/]+/(?i:PyYAML-)[\d\.]+.(tar.(gz|xz|bz2)|zip)",  # noqa: E501
                 )
             elif data.filename == "vdf-3.1-py2.py3-none-any.whl":
                 self.assertRegex(


### PR DESCRIPTION
Upstream keeps having issues in their CI pipelines, resulting in massively delayed tarball uploads. Gentoo has been doing custom uploads in the interim, so try to automatically fall back to those URLs on 404.