### PR TITLE
chromiumchecker: Fix Gentoo-hosted tarball URL

### DIFF
--- a/src/checkers/chromiumchecker.py
+++ b/src/checkers/chromiumchecker.py
@@ -62,7 +62,7 @@ class ChromiumComponent(Component):
     )
     # https://groups.google.com/a/chromium.org/g/chromium-packagers/c/wjv9UKg2u4w/m/SwSvLazmCAAJ
     _GENTOO_URL_FORMAT = (
-        "https://chromium-tarballs.distfiles.gentoo.org/chromium-{version}.tar.xz"
+        "https://chromium-tarballs.distfiles.gentoo.org/chromium-{version}-linux.tar.xz"
     )
 
     async def check(self) -> None:


### PR DESCRIPTION
Since [this commit on chromium-tarballs](https://github.com/chromium-linux-tarballs/chromium-tarballs/commit/a10667b4f040ac6ea3c77bfd9a41e4d44ff8d0a0), the Gentoo tarball has the format `chromium-${version}-linux.tar.xz`. Update the URL template so that this fallback is actually useful.