### PR TITLE
tests: Fix boost source and x-checker data

### DIFF
--- a/tests/org.flatpak.Flatpak.yml
+++ b/tests/org.flatpak.Flatpak.yml
@@ -28,13 +28,13 @@ modules:
   - name: boost
     sources:
       - type: archive
-        url: https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.tar.bz2
+        url: https://archives.boost.io/release/1.74.0/source/boost_1_74_0.tar.bz2
         sha256: 83bfc1507731a0906e387fc28b7ef5417d591429e51e788417fe9ff025e116b1
         x-checker-data:
           type: anitya
           project-id: 6845
           stable-only: true
-          url-template: https://boostorg.jfrog.io/artifactory/main/release/$version/source/boost_${major}_${minor}_$patch.tar.bz2
+          url-template: https://archives.boost.io/release/$version/source/boost_${major}_${minor}_$patch.tar.bz2
 
   - name: glib-networking
     sources:

--- a/tests/test_anityachecker.py
+++ b/tests/test_anityachecker.py
@@ -46,7 +46,7 @@ class TestAnityaChecker(unittest.IsolatedAsyncioTestCase):
                 self.assertIsInstance(data.new_version, ExternalFile)
                 self.assertRegex(
                     data.new_version.url,
-                    r"^https://boostorg\.jfrog\.io/artifactory/main/release/[\d.]+/source/boost_[\d]+_[\d]+_[\d]+.tar.bz2$",  # noqa: E501
+                    r"^https://archives\.boost\.io/release/[\d.]+/source/boost_[\d]+_[\d]+_[\d]+.tar.bz2$",  # noqa: E501
                 )
                 self.assertIsNotNone(data.new_version.version)
                 self.assertGreater(


### PR DESCRIPTION
jfrog now goes to a landing page, https://www.boost.org/users/download/ points to archives.boost.io instead