### PR TITLE
gnomechecker: Add enum to detect unstable versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,7 +393,11 @@ Check for latest source tarball for a GNOME project.
 }
 ```
 
-Set `stable-only` to `false` to check for pre-releases, too.
+Set `stable-only` to `false` to check for pre-releases, too. By default, any
+version that contains the string `alpha`, `beta` or `rc` is considered a
+pre-release, following the dominant convention since GNOME 40. To override this,
+set `version-scheme` to `odd-minor-is-unstable` to consider any version with an
+odd second component to be a pre-release.
 
 The [`versions`](#version-constraining) property is supported.
 

--- a/tests/org.gnome.baobab.json
+++ b/tests/org.gnome.baobab.json
@@ -30,6 +30,7 @@
                         "type": "gnome",
                         "name": "pygobject",
                         "stable-only": false,
+                        "version-scheme": "odd-minor-is-unstable",
                         "versions": {
                             "<": "3.38"
                         }
@@ -66,6 +67,21 @@
             ]
         },
         {
+            "name" : "tracker",
+            "sources" : [
+                {
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/tracker/3.4/tracker-3.4.2.tar.xz",
+                    "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "x-checker-data": {
+                        "type": "gnome",
+                        "name": "tracker",
+                        "version-scheme": "odd-minor-is-unstable"
+                    }
+                }
+            ]
+        },
+        {
             "name" : "cairo-static",
             "sources" : [
                 {
@@ -75,6 +91,7 @@
                     "x-checker-data": {
                         "type": "gnome",
                         "name": "cairo",
+                        "version-scheme": "odd-minor-is-unstable",
                         "versions": {
                             ">": "9999.0.0"
                         }


### PR DESCRIPTION
Adds an enum that allows specifying how unstable versions should be detected. Few modules are still being released and are not using the new GNOME version scheme.

This solves, for example libadwaita 1.7 being picked as unstable. 

cc: @alatiera @wjt

Supersedes: https://github.com/flathub-infra/flatpak-external-data-checker/pull/435