### PR TITLE
Changelog urls

### DIFF
--- a/src/checkers/anityachecker.py
+++ b/src/checkers/anityachecker.py
@@ -100,6 +100,7 @@ class AnityaChecker(Checker):
             branch=None,
             version=latest_version,
             timestamp=None,
+            changelog_url=None,
         ).fetch_remote()
 
         external_data.set_new_version(new_version)

--- a/src/checkers/chromiumchecker.py
+++ b/src/checkers/chromiumchecker.py
@@ -137,6 +137,7 @@ class LLVMGitComponent(LLVMComponent):
             branch=None,
             version=self.latest_version,
             timestamp=None,
+            changelog_url=None,
         )
         self.external_data.set_new_version(new_version)
 

--- a/src/checkers/debianrepochecker.py
+++ b/src/checkers/debianrepochecker.py
@@ -154,6 +154,7 @@ class DebianRepoChecker(Checker):
                     # Strip epoch if present
                     version=re.sub(r"^\d+:", "", source_version),
                     timestamp=await get_timestamp_from_url(src_url, self.session),
+                    changelog_url=None,
                 )
             else:
                 package = cache[package_name]
@@ -171,6 +172,7 @@ class DebianRepoChecker(Checker):
                     size=candidate.size,
                     version=candidate.version,
                     timestamp=await self._get_timestamp_for_candidate(candidate),
+                    changelog_url=None,
                 )
 
             external_data.set_new_version(new_version)

--- a/src/checkers/electronchecker.py
+++ b/src/checkers/electronchecker.py
@@ -78,6 +78,7 @@ class ElectronChecker(Checker):
             size=file_size,
             version=metadata["version"],
             timestamp=timestamp,
+            changelog_url=None,
         )
 
         await self._set_new_version(external_data, new_version)

--- a/src/checkers/gitchecker.py
+++ b/src/checkers/gitchecker.py
@@ -150,6 +150,7 @@ class GitChecker(Checker):
             branch=None,
             version=latest_tag.version,
             timestamp=None,
+            changelog_url=None,
         )
         external_data.set_new_version(new_version)
 

--- a/src/checkers/gnomechecker.py
+++ b/src/checkers/gnomechecker.py
@@ -116,6 +116,7 @@ class GNOMEChecker(Checker):
             size=None,
             version=latest_version,
             timestamp=None,
+            changelog_url=None,
         )
 
         external_data.set_new_version(new_version)

--- a/src/checkers/jetbrainschecker.py
+++ b/src/checkers/jetbrainschecker.py
@@ -50,6 +50,7 @@ class JetBrainsChecker(Checker):
             size=release["size"],
             version=data["version"],
             timestamp=datetime.datetime.strptime(data["date"], "%Y-%m-%d"),
+            changelog_url=None,
         )
 
         external_data.set_new_version(new_version)

--- a/src/checkers/jsonchecker.py
+++ b/src/checkers/jsonchecker.py
@@ -212,6 +212,7 @@ class JSONChecker(Checker):
             branch=None,
             version=results.get("version"),
             timestamp=parse_timestamp(results.get("timestamp")),
+            changelog_url=None,
         )
 
         if new_version.commit is None:

--- a/src/checkers/pypichecker.py
+++ b/src/checkers/pypichecker.py
@@ -102,5 +102,6 @@ class PyPIChecker(Checker):
             size=pypi_download["size"],
             version=pypi_version.orig_str,
             timestamp=pypi_date,
+            changelog_url=None,
         )
         external_data.set_new_version(new_version)

--- a/src/checkers/rpmrepochecker.py
+++ b/src/checkers/rpmrepochecker.py
@@ -49,6 +49,7 @@ class RPMRepoChecker(Checker):
             size=int(child_prop("size", "archive")),
             version=child_prop("version", "ver"),
             timestamp=datetime.utcfromtimestamp(int(child_prop("time", "file"))),
+            changelog_url=None,
         )
 
     async def check(self, external_data: ExternalBase):

--- a/src/checkers/rustchecker.py
+++ b/src/checkers/rustchecker.py
@@ -57,5 +57,6 @@ class RustChecker(Checker):
                 size=None,
                 version=appstream_version,
                 timestamp=release_date,
+                changelog_url=None,
             )
             external_data.set_new_version(new_version)

--- a/src/checkers/snapcraftchecker.py
+++ b/src/checkers/snapcraftchecker.py
@@ -70,6 +70,7 @@ class SnapcraftChecker(Checker):
                     timestamp=datetime.datetime.strptime(
                         data["channel"]["released-at"], "%Y-%m-%dT%H:%M:%S.%f%z"
                     ),
+                    changelog_url=None,
                 )
 
                 external_data.set_new_version(new_version)

--- a/src/lib/utils.py
+++ b/src/lib/utils.py
@@ -181,6 +181,7 @@ async def get_extra_data_info_from_url(
         size=size,
         version=None,
         timestamp=_extract_timestamp(info),
+        changelog_url=None,
     )
 
     return external_file

--- a/src/main.py
+++ b/src/main.py
@@ -98,6 +98,8 @@ def print_outdated_external_data(manifest_checker: manifest.ManifestChecker):
                 "  Version:   {version}",
                 "  Timestamp: {timestamp}",
             ]
+            if message_args["changelog_url"]:
+                message_tmpl.append("  Changelog: {changelog_url}")
         elif data.State.BROKEN in data.state:
             message_tmpl = [
                 "{data_state}: {data_name}",

--- a/src/main.py
+++ b/src/main.py
@@ -284,7 +284,12 @@ def commit_changes(changes: t.List[str]) -> CommittedChanges:
     except subprocess.CalledProcessError:
         # If not, create it
         check_call(["git", "checkout", "-b", branch])
-    log.debug("Commited with subject='%s', message='%s', body='%s'", subject, repr(message), repr(body))
+    log.debug(
+        "committed with subject='%s', message='%s', body='%s'",
+        subject,
+        repr(message),
+        repr(body),
+    )
     return CommittedChanges(
         subject=subject,
         body=body,

--- a/src/main.py
+++ b/src/main.py
@@ -65,51 +65,47 @@ def print_outdated_external_data(manifest_checker: manifest.ManifestChecker):
     ext_data = manifest_checker.get_outdated_external_data()
     for data in ext_data:
         state_txt = data.state.name or str(data.state)
-        message_tmpl = ""
+        message_tmpl = [
+            "{data_state}: {data_name}",
+            " Has a new version:",
+            "  URL:       {url}",
+        ]
         message_args = {}
         if data.new_version:
             if data.type == data.Type.GIT:
                 assert data.new_version
-                message_tmpl = (
-                    "{data_state}: {data_name}\n"
-                    " Has a new version:\n"
-                    "  URL:       {url}\n"
-                    "  Commit:    {commit}\n"
-                    "  Tag:       {tag}\n"
-                    "  Branch:    {branch}\n"
-                    "  Version:   {version}\n"
-                    "  Timestamp: {timestamp}\n"
-                )
+                message_tmpl += [
+                    "  Commit:    {commit}",
+                    "  Tag:       {tag}",
+                    "  Branch:    {branch}",
+                ]
                 message_args = data.new_version._asdict()
             else:
                 assert isinstance(data, ExternalData)
                 assert data.new_version
-                message_tmpl = (
-                    "{data_state}: {data_name}\n"
-                    " Has a new version:\n"
-                    "  URL:       {url}\n"
-                    "  MD5:       {md5}\n"
-                    "  SHA1:      {sha1}\n"
-                    "  SHA256:    {sha256}\n"
-                    "  SHA512:    {sha512}\n"
-                    "  Size:      {size}\n"
-                    "  Version:   {version}\n"
-                    "  Timestamp: {timestamp}\n"
-                )
+                message_tmpl += [
+                    "  MD5:       {md5}",
+                    "  SHA1:      {sha1}",
+                    "  SHA256:    {sha256}",
+                    "  SHA512:    {sha512}",
+                    "  Size:      {size}",
+                ]
                 message_args = {
                     **data.new_version._asdict(),
                     **data.new_version.checksum._asdict(),
                 }
+            message_tmpl += [
+                "  Version:   {version}",
+                "  Timestamp: {timestamp}",
+            ]
         elif data.State.BROKEN in data.state:
-            message_tmpl = (
-                # fmt: off
-                "{data_state}: {data_name}\n"
-                " Couldn't get new version for {url}\n"
-                # fmt: on
-            )
+            message_tmpl = [
+                "{data_state}: {data_name}",
+                " Couldn't get new version for {url}",
+            ]
             message_args = data.current_version._asdict()
 
-        message = message_tmpl.format(
+        message = "\n".join(message_tmpl).format(
             data_state=state_txt,
             data_name=data.filename,
             **message_args,

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -450,13 +450,15 @@ class ManifestChecker:
             if data.new_version is None:
                 continue
 
+            changelog = "\nChangelog: " + data.new_version.changelog_url if data.new_version.changelog_url else ""
+
             data.update()
             if data.new_version.version is not None:
-                message = "{}: Update {} to {}".format(
-                    data.module, data.filename, data.new_version.version
+                message = "{}: Update {} to {}{}".format(
+                    data.module, data.filename, data.new_version.version, changelog
                 )
             else:
-                message = "{}: Update {}".format(data.module, data.filename)
+                message = "{}: Update {}{}".format(data.module, data.filename, changelog)
 
             changes[message] = None
             path_has_changes = True

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -450,7 +450,10 @@ class ManifestChecker:
             if data.new_version is None:
                 continue
 
-            changelog = "\nChangelog: " + data.new_version.changelog_url if data.new_version.changelog_url else ""
+            if data.new_version.changelog_url:
+                changelog = "\nChangelog: " + data.new_version.changelog_url
+            else:
+                changelog = ""
 
             data.update()
             if data.new_version.version is not None:
@@ -458,7 +461,9 @@ class ManifestChecker:
                     data.module, data.filename, data.new_version.version, changelog
                 )
             else:
-                message = "{}: Update {}{}".format(data.module, data.filename, changelog)
+                message = "{}: Update {}{}".format(
+                    data.module, data.filename, changelog
+                )
 
             changes[message] = None
             path_has_changes = True

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -194,44 +194,44 @@ class TestManifestLoader(unittest.IsolatedAsyncioTestCase):
             self.assertFalse(data2.is_same_version(data1))
 
         assertSame(
-            ExternalGitRef("http://example.com", None, None, "a", "v1.0", None),
-            ExternalGitRef("http://example.com", None, None, "b", "v1.0", None),
+            ExternalGitRef("http://example.com", None, None, None, "a", "v1.0", None),
+            ExternalGitRef("http://example.com", None, None, None, "b", "v1.0", None),
         )
         assertDiff(
-            ExternalGitRef("http://example.com", None, None, "a", "v1.0", None),
-            ExternalGitRef("http://example.com", None, None, "b", "v1.1", None),
+            ExternalGitRef("http://example.com", None, None, None, "a", "v1.0", None),
+            ExternalGitRef("http://example.com", None, None, None, "b", "v1.1", None),
         )
         assertDiff(
-            ExternalGitRef("http://example.com", None, None, "a", "v1.0", None),
-            ExternalGitRef("http://example.com", None, None, "a", "v1.1", None),
+            ExternalGitRef("http://example.com", None, None, None, "a", "v1.0", None),
+            ExternalGitRef("http://example.com", None, None, None, "a", "v1.1", None),
         )
         assertDiff(
-            ExternalGitRef("http://example.com", None, None, "a", "v1.0", "same"),
-            ExternalGitRef("http://example.com", None, None, "a", "v1.1", "same"),
+            ExternalGitRef("http://example.com", None, None, None, "a", "v1.0", "same"),
+            ExternalGitRef("http://example.com", None, None, None, "a", "v1.1", "same"),
         )
         assertDiff(
-            ExternalGitRef("http://example.com", None, None, "a", "v1.0", "one"),
-            ExternalGitRef("http://example.com", None, None, "a", "v1.0", "two"),
+            ExternalGitRef("http://example.com", None, None, None, "a", "v1.0", "one"),
+            ExternalGitRef("http://example.com", None, None, None, "a", "v1.0", "two"),
         )
         # No tag, same branch
         assertSame(
-            ExternalGitRef("http://example.com", None, None, "a", None, "same"),
-            ExternalGitRef("http://example.com", None, None, "b", None, "same"),
+            ExternalGitRef("http://example.com", None, None, None, "a", None, "same"),
+            ExternalGitRef("http://example.com", None, None, None, "b", None, "same"),
         )
         # No tag, different branches
         assertDiff(
-            ExternalGitRef("http://example.com", None, None, "a", None, "one"),
-            ExternalGitRef("http://example.com", None, None, "b", None, "two"),
+            ExternalGitRef("http://example.com", None, None, None, "a", None, "one"),
+            ExternalGitRef("http://example.com", None, None, None, "b", None, "two"),
         )
         # No tag or branch, same commit
         assertSame(
-            ExternalGitRef("http://example.com", None, None, "a", None, None),
-            ExternalGitRef("http://example.com", None, None, "a", None, None),
+            ExternalGitRef("http://example.com", None, None, None, "a", None, None),
+            ExternalGitRef("http://example.com", None, None, None, "a", None, None),
         )
         # No tag or branch, different commits
         assertDiff(
-            ExternalGitRef("http://example.com", None, None, "a", None, None),
-            ExternalGitRef("http://example.com", None, None, "b", None, None),
+            ExternalGitRef("http://example.com", None, None, None, "a", None, None),
+            ExternalGitRef("http://example.com", None, None, None, "b", None, None),
         )
 
     def test_load(self):


### PR DESCRIPTION
Work in progress for #339 

Let's see how the ci feels about it but I assume that the other checkers will fail. Let me know if you have a better idea than adding `changelog_url=None` to each of them.

And of course, let me know what you think of this in general.

Branch with data for testing: https://github.com/flathub/com.github.jeromerobert.pdfarranger/tree/tmp-pre-pdfarranger-update
(the larger part already auto-generated via https://github.com/flatpak/flatpak-builder-tools/pull/440

