### PR TITLE
gnomechecker: Allow major version 0 being stable

### DIFF
--- a/src/checkers/gnomechecker.py
+++ b/src/checkers/gnomechecker.py
@@ -49,7 +49,7 @@ def _is_stable(
         if any(_contains_keyword(x) for x in ver_list[1:]):
             return False
     elif scheme == VersionScheme.ODD_MINOR_IS_UNSTABLE:
-        if int(major) > 0 and len(ver_list) >= 2:
+        if len(ver_list) >= 2:
             return (int(minor) % 2) == 0
 
     # XXX If we didn't see any indication that the version is a prerelease,

--- a/tests/test_gnomechecker.py
+++ b/tests/test_gnomechecker.py
@@ -64,6 +64,7 @@ class TestGNOMEChecker(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(_is_stable("2.2.2", scheme))
         self.assertTrue(_is_stable("1.2.2", scheme))
         self.assertTrue(_is_stable("1.2.1", scheme))
+        self.assertTrue(_is_stable("0.10.0", scheme))
 
         self.assertFalse(_is_stable("1.1", scheme))
         self.assertFalse(_is_stable("1.1.0", scheme))
@@ -72,6 +73,7 @@ class TestGNOMEChecker(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(_is_stable("2.3.2", scheme))
         self.assertFalse(_is_stable("1.1.2", scheme))
         self.assertFalse(_is_stable("1.3.1", scheme))
+        self.assertFalse(_is_stable("0.11.0", scheme))
 
     async def test_check(self):
         checker = ManifestChecker(TEST_MANIFEST)


### PR DESCRIPTION
libdex has 0.10.0 as its latest stable release and the checker detects 0.11.0 as an update, but this version is unstable.

Updates from a major version of 0 to another major version =0 are not an issue, since the app was using such a major version in the first place.