### PR TITLE
manifest: Don't allow invalid appdata when change is a downgrade

### DIFF
--- a/dependencies.apt.txt
+++ b/dependencies.apt.txt
@@ -1,4 +1,5 @@
 bubblewrap
+gir1.2-appstream-1.0
 gir1.2-glib-2.0
 gir1.2-json-1.0
 git

--- a/src/lib/utils.py
+++ b/src/lib/utils.py
@@ -50,8 +50,10 @@ from .checksums import MultiHash
 
 import gi
 
+gi.require_version("AppStream", "1.0")
+gi.require_version("Gio", "2.0")
 gi.require_version("Json", "1.0")
-from gi.repository import GLib, Json  # noqa: E402
+from gi.repository import AppStream, Gio, GLib, Json  # noqa: E402
 
 log = logging.getLogger(__name__)
 
@@ -582,3 +584,29 @@ def init_logging(level=logging.DEBUG):
     logging.basicConfig(level=level, format="%(levelname)-7s %(name)s: %(message)s")
     if level == logging.DEBUG:
         logging.getLogger("github.Requester").setLevel(logging.INFO)
+
+
+def validate_metainfo_file(path: str) -> tuple[bool, list[str]]:
+    if not os.path.isfile(path):
+        return (False, [])
+
+    validator = AppStream.Validator()
+    gfile = Gio.File.new_for_path(path)
+
+    result = validator.validate_file(gfile)
+    validation_errs: list[str] = []
+
+    if result:
+        return (True, validation_errs)
+    else:
+        issues = validator.get_issues()
+        for issue in issues:
+            severity = issue.get_severity()
+            if severity in (
+                AppStream.IssueSeverity.ERROR,
+                AppStream.IssueSeverity.WARNING,
+            ):
+                message = issue.get_explanation()
+                if message:
+                    validation_errs.append(message.strip())
+    return (False, validation_errs)

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -26,7 +26,7 @@ import asyncio
 from enum import IntEnum
 import logging
 import os
-
+import shutil
 import aiohttp
 from lxml.etree import XMLSyntaxError
 
@@ -36,12 +36,13 @@ from .lib.externaldata import (
     BuilderModule,
     ExternalBase,
 )
-from .lib.utils import read_manifest, dump_manifest
+from .lib.utils import read_manifest, dump_manifest, validate_metainfo_file
 from .lib.errors import (
     CheckerError,
     AppdataError,
     AppdataNotFound,
     AppdataLoadError,
+    AppdataUpdateError,
     ManifestLoadError,
     ManifestFileTooLarge,
     ManifestFileOpenError,
@@ -517,12 +518,28 @@ class ManifestChecker:
                 timestamp = datetime.datetime.now()
             else:
                 timestamp = last_update.timestamp
+
+            backup_path = appdata + ".backup"
+
+            shutil.copy2(appdata, backup_path)
+            is_valid_before, _ = validate_metainfo_file(appdata)
             try:
                 add_release_to_file(
                     appdata, last_update.version, timestamp.strftime("%F")
                 )
+                is_valid_now, errs = validate_metainfo_file(appdata)
+                if is_valid_before and not is_valid_now:
+                    log.error(
+                        "Appdata validation failed after adding new release: %s", errs
+                    )
+                    shutil.copy2(backup_path, appdata)
+                    raise AppdataUpdateError("Appdata validation failed")
             except XMLSyntaxError as err:
+                shutil.copy2(backup_path, appdata)
                 raise AppdataLoadError from err
+            finally:
+                if os.path.exists(backup_path):
+                    os.unlink(backup_path)
         else:
             log.debug("Version didn't change, not adding release")
 
@@ -566,7 +583,6 @@ class ManifestChecker:
                 except AppdataError as err:
                     self._errors.append(err)
                     log.error(err)
-
         else:
             log.info("No important source had an update, not updating manifest")
 


### PR DESCRIPTION
Instead restore the original appdata back

Fixes https://github.com/flathub-infra/flatpak-external-data-checker/issues/36