### PR TITLE
tests: Update debian channel to bookworm

### DIFF
--- a/tests/org.debian.tracker.pkg.apt.yml
+++ b/tests/org.debian.tracker.pkg.apt.yml
@@ -8,7 +8,7 @@ modules:
             x-checker-data:
               type: debian-repo
               root: http://deb.debian.org/debian/
-              dist: buster
+              dist: bookworm
               component: main
               package-name: python-apt
               source: true
@@ -23,6 +23,6 @@ modules:
                 x-checker-data:
                   type: debian-repo
                   root: http://deb.debian.org/debian
-                  dist: buster
+                  dist: bookworm
                   component: main
                   package-name: apt


### PR DESCRIPTION
buster is eol and tests are failing as the repo links are 404