### PR TITLE
increase the maximum size of the manifest file

### DIFF
--- a/src/manifest.py
+++ b/src/manifest.py
@@ -53,7 +53,7 @@ from .checkers import Checker, ALL_CHECKERS
 
 MAIN_SRC_PROP = "is-main-source"
 IMPORTANT_SRC_PROP = "is-important"
-MAX_MANIFEST_SIZE = 1024 * 100
+MAX_MANIFEST_SIZE = 1024 * 1024
 
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
The org.kde.Sdk manifest file is bigger (110 KiB) and this makes it not work. This change increases it to 1MiB.