### PR TITLE
Support more ca certificates path

### DIFF
--- a/src/lib/utils.py
+++ b/src/lib/utils.py
@@ -420,6 +420,7 @@ async def git_ls_remote(url: str) -> t.Dict[str, str]:
         allow_paths=[
             Command.SandboxPath("/etc/ssl", True, True),
             Command.SandboxPath("/etc/pki", True, True),
+            Command.SandboxPath("/var/lib/ca-certificates", True, True),
             Command.SandboxPath("/etc/resolv.conf", True, False),
         ],
     )


### PR DESCRIPTION
On openSUSE Tumbleweed, the CA certificates in `/etc/ssl` is soft linked to another directory, resulting `git_ls_remote` can't access any HTTPS resources:

```
ls -alh /etc/ssl
total 48K
drwxr-xr-x. 1 root root  134 Jan 19  2026 .
drwxr-xr-x. 1 root root 3.8K Jan 19 00:34 ..
lrwxrwxrwx. 1 root root   33 Oct  6 21:31 certs -> ../../var/lib/ca-certificates/pem
drwx------. 1 root root    0 Sep 17 08:56 private
lrwxrwxrwx. 1 root root   43 Oct  6 21:31 ca-bundle.pem -> ../../var/lib/ca-certificates/ca-bundle.pem
-rw-r--r--. 1 root root  412 Sep 17 08:56 ct_log_list.cnf
-rw-r--r--. 1 root root  13K Sep 17 08:56 openssl.cnf
-rw-r--r--. 1 root root  13K Sep 17 08:56 openssl-orig.cnf
```