### PR TITLE
Add environment proxy support to aiohttp

### DIFF
--- a/src/manifest.py
+++ b/src/manifest.py
@@ -405,6 +405,7 @@ class ManifestChecker:
             raise_for_status=True,
             headers=HTTP_CLIENT_HEADERS,
             timeout=aiohttp.ClientTimeout(connect=TIMEOUT_CONNECT, total=TIMEOUT_TOTAL),
+            trust_env=True,
         ) as http_session:
             check_tasks = []
             for data in external_data:


### PR DESCRIPTION
This change adds support for environment HTTP(s) proxy  with the `trust_env` flag in `aiohttp.ClientSession`. This feature allows flatpak-external-data-checker to fetch data while being behind a network proxy such as squid. 

Reference: https://docs.aiohttp.org/en/stable/client_advanced.html#aiohttp-client-proxy-support