### PR TITLE
gnome: Do not crash if minor is not numeric

### DIFF
--- a/src/checkers/gnomechecker.py
+++ b/src/checkers/gnomechecker.py
@@ -49,6 +49,14 @@ def _is_stable(
         if any(_contains_keyword(x) for x in ver_list[1:]):
             return False
     elif scheme == VersionScheme.ODD_MINOR_IS_UNSTABLE:
+        # This is preferable over crashing if minor is not an int
+        if not minor.isdigit():
+            log.warning(
+                "odd-minor-is-unstable is used but minor in version %s is not numeric",
+                version,
+            )
+            return False
+
         if len(ver_list) >= 2:
             return (int(minor) % 2) == 0
 

--- a/tests/test_gnomechecker.py
+++ b/tests/test_gnomechecker.py
@@ -75,6 +75,9 @@ class TestGNOMEChecker(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(_is_stable("1.3.1", scheme))
         self.assertFalse(_is_stable("0.11.0", scheme))
 
+        # This should at least not crash
+        self.assertFalse(_is_stable("40.alpha", scheme))
+
     async def test_check(self):
         checker = ManifestChecker(TEST_MANIFEST)
         ext_data = await checker.check()


### PR DESCRIPTION
when the odd-minor-is-unstable version scheme is used. Instead we simply say it is not stable, the minor should be numerical with this scheme.

This fixes a crash when checking libgweather versions which uses this scheme but has a 40.alpha release.