### PR TITLE
utils: Use asyncio.gather with fail-fast behaviour

### DIFF
--- a/src/lib/utils.py
+++ b/src/lib/utils.py
@@ -57,6 +57,8 @@ from gi.repository import (  # type: ignore[attr-defined] # noqa: E402 # noqa: I
     Json,
 )
 
+T = t.TypeVar("T")
+
 log = logging.getLogger(__name__)
 
 
@@ -628,3 +630,29 @@ def init_logging(level=logging.DEBUG):
     logging.basicConfig(level=level, format="%(levelname)-7s %(name)s: %(message)s")
     if level == logging.DEBUG:
         logging.getLogger("github.Requester").setLevel(logging.INFO)
+
+
+async def asyncio_gather_failfast(
+    awaitables: t.Iterable[t.Awaitable[T]],
+) -> list[T]:
+    tasks: list[asyncio.Task[T]] = [asyncio.ensure_future(a) for a in awaitables]
+    if not tasks:
+        return []
+    done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_EXCEPTION)
+    exc: BaseException | None = None
+    for task in done:
+        if task.cancelled():
+            continue
+        try:
+            e = task.exception()
+        except asyncio.CancelledError:
+            continue
+        if e is not None:
+            exc = e
+            break
+    if exc:
+        for task in pending:
+            task.cancel()
+        await asyncio.gather(*pending, return_exceptions=True)
+        raise exc
+    return [task.result() for task in tasks]

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -18,7 +18,6 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-import asyncio
 import dataclasses
 import datetime
 import logging
@@ -48,7 +47,7 @@ from .lib.externaldata import (
     BuilderModule,
     ExternalBase,
 )
-from .lib.utils import dump_manifest, read_manifest
+from .lib.utils import asyncio_gather_failfast, dump_manifest, read_manifest
 
 MAIN_SRC_PROP = "is-main-source"
 IMPORTANT_SRC_PROP = "is-important"
@@ -417,7 +416,7 @@ class ManifestChecker:
                 check_tasks.append(self._check_data(counter, http_session, data))
 
             log.info("Checking %s external data items", counter.total)
-            ext_data_checked = await asyncio.gather(*check_tasks)
+            ext_data_checked = await asyncio_gather_failfast(check_tasks)
 
         return ext_data_checked
 

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -92,6 +92,22 @@ class UpdateEverythingChecker(DummyChecker, register=False):
         )
 
 
+class RaisesAssertionChecker(DummyChecker, register=False):
+    async def check(self, external_data):
+        raise AssertionError("test error")
+
+
+class TestFailFast(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        init_logging()
+
+    async def test_unexpected_exception_propagates(self):
+        checker = manifest.ManifestChecker(TEST_MANIFEST)
+        checker._checkers = [RaisesAssertionChecker]
+        with self.assertRaises(AssertionError):
+            await checker.check()
+
+
 class _TestWithInlineManifest(unittest.IsolatedAsyncioTestCase):
     _DUMMY_CHECKER_CLS: type[Checker]
     maxDiff = None

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+import asyncio
 import re
 import subprocess
 import unittest
@@ -34,6 +35,7 @@ from src.lib.utils import (
     Command,
     FallbackVersion,
     _detect_json_flatpak_manifest_indent,
+    asyncio_gather_failfast,
     dump_manifest,
     filter_versioned_items,
     filter_versions,
@@ -509,6 +511,81 @@ class TestDumpManifest(unittest.TestCase):
             path.write_text(original)
             dump_manifest(EDITORCONFIG_SAMPLE_DATA, path)
             self.assertEqual(path.read_text(), expected_data)
+
+
+class TestGatherFailfast(unittest.IsolatedAsyncioTestCase):
+    async def test_all_succeed(self):
+        async def succeed(val):
+            return val
+
+        result = await asyncio_gather_failfast([succeed(1), succeed(2), succeed(3)])
+        self.assertEqual(result, [1, 2, 3])
+
+    async def test_empty(self):
+        result = await asyncio_gather_failfast([])
+        self.assertEqual(result, [])
+
+    async def test_exception_cancels_pending(self):
+        cancelled = False
+
+        async def hang():
+            nonlocal cancelled
+            try:
+                await asyncio.sleep(999)
+            except asyncio.CancelledError:
+                cancelled = True
+                raise
+
+        async def fail():
+            raise AssertionError("test error")
+
+        with self.assertRaises(AssertionError):
+            await asyncio_gather_failfast([hang(), fail()])
+
+        self.assertTrue(cancelled)
+
+    async def test_exception_propagates(self):
+        async def fail():
+            raise ValueError("test error")
+
+        with self.assertRaises(ValueError, msg="test error"):
+            await asyncio_gather_failfast([fail()])
+
+    async def test_parent_child_hang(self):
+        event = asyncio.Event()
+        child_cancelled = False
+
+        async def parent():
+            raise AssertionError("test error")
+
+        async def child():
+            nonlocal child_cancelled
+            try:
+                await event.wait()
+            except asyncio.CancelledError:
+                child_cancelled = True
+                raise
+
+        with self.assertRaises(AssertionError):
+            await asyncio_gather_failfast([parent(), child()])
+
+        self.assertTrue(child_cancelled)
+
+    async def test_sibling_cancelled_on_exception(self):
+        async def raises_assert():
+            raise AssertionError("test error")
+
+        async def slow():
+            await asyncio.sleep(999)
+
+        with self.assertRaises((AssertionError, asyncio.TimeoutError)):
+            await asyncio.wait_for(
+                asyncio.gather(raises_assert(), slow()),
+                timeout=2.0,
+            )
+
+        with self.assertRaises(AssertionError):
+            await asyncio_gather_failfast([raises_assert(), slow()])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
asyncio.gather does not cancel sibling tasks when one fails, so if one
checker raises an unhandled exception, other tasks running I/O may keep
the event loop alive indefinitely. So use asyncio_gather_failfast to
detect failures and explicitly cancel+drain all pending tasks before
re-raising the exception.

In Python 3.11+ this is offered by TaskGroup but it is cheap to
use a wrapper here.

See https://github.com/python/cpython/issues/75633

Fixes: https://github.com/flathub-infra/flatpak-external-data-checker/issues/420