### PR TITLE
tests: Use heroic appimage instead of unityhub

### DIFF
--- a/tests/com.heroicgameslauncher.hgl.yaml
+++ b/tests/com.heroicgameslauncher.hgl.yaml
@@ -1,0 +1,9 @@
+app-id: com.heroicgameslauncher.hgl
+modules:
+  - name: heroic
+    sources:
+      - type: extra-data
+        filename: Heroic-2.21.0-linux-x86_64.AppImage
+        url: https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/releases/download/v2.21.0/Heroic-2.21.0-linux-x86_64.AppImage
+        sha256: "0000000000000000000000000000000000000000000000000000000000000000"
+        size: 0

--- a/tests/com.unity.UnityHub.yaml
+++ b/tests/com.unity.UnityHub.yaml
@@ -1,9 +1,0 @@
-app-id: com.unity.UnityHub
-modules:
-  - name: unityhub
-    sources:
-      - type: extra-data
-        filename: UnityHubSetup.AppImage
-        url: https://public-cdn.cloud.unity3d.com/hub/prod/UnityHub.AppImage
-        sha256: "0000000000000000000000000000000000000000000000000000000000000000"
-        size: 0

--- a/tests/test_urlchecker.py
+++ b/tests/test_urlchecker.py
@@ -12,13 +12,15 @@ class TestURLChecker(unittest.IsolatedAsyncioTestCase):
 
     async def test_check_appimage(self):
         checker = ManifestChecker(
-            os.path.join(os.path.dirname(__file__), "com.unity.UnityHub.yaml")
+            os.path.join(os.path.dirname(__file__), "com.heroicgameslauncher.hgl.yaml")
         )
         ext_data = await checker.check()
 
-        data = self._find_by_filename(ext_data, "UnityHubSetup.AppImage")
+        filename = "Heroic-2.21.0-linux-x86_64.AppImage"
+        data = self._find_by_filename(ext_data, filename)
+
         self.assertIsNotNone(data)
-        self.assertEqual(data.filename, "UnityHubSetup.AppImage")
+        self.assertEqual(data.filename, filename)
         self.assertIsNotNone(data.new_version)
         self.assertIsInstance(data.new_version.size, int)
         self.assertGreater(data.new_version.size, 0)


### PR DESCRIPTION
Latter is 404, looks like DEB and RPM are the only ones supported right now in the portal. This also makes sure network-ed tests rely on GitHub only.

It failed in https://github.com/flathub-infra/flatpak-external-data-checker/pull/512, https://github.com/flathub-infra/flatpak-external-data-checker/actions/runs/24840827113/job/72714026562#step:5:484