### PR TITLE
tests: Use major minor and patch in boost's URL template

### DIFF
--- a/tests/org.flatpak.Flatpak.yml
+++ b/tests/org.flatpak.Flatpak.yml
@@ -24,7 +24,7 @@ modules:
           versions:
             ==: "1.10.1"
           url-template: https://github.com/flatpak/flatpak/releases/download/$version/flatpak-$version.tar.xz
-          
+
   - name: boost
     sources:
       - type: archive
@@ -34,7 +34,7 @@ modules:
           type: anitya
           project-id: 6845
           stable-only: true
-          url-template: https://archives.boost.io/release/$version/source/boost_${major}_${minor}_$patch.tar.bz2
+          url-template: https://archives.boost.io/release/${major}.${minor}.${patch}/source/boost_${major}_${minor}_$patch.tar.bz2
 
   - name: glib-networking
     sources:


### PR DESCRIPTION
The $version adds some rebuild suffix to it making the test fail

```
ERROR src.manifest: Failed to check archive boost/boost_1_74_0.tar.bz2 with AnityaChecker: Error downloading upstream source: 404... url=URL('https://archives.boost.io/release/1.91.0-1/source/boost_1_91_0.tar.bz2')
```