### PR TITLE
ci: Run coveralls inside venv

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -121,7 +121,7 @@ jobs:
         run: |
           python3 -m venv venv
           . venv/bin/activate
-          pip install coveralls
+          pip install 'coveralls==4.1.0'
           coveralls
 
       - name: Login to registry

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -115,6 +115,7 @@ jobs:
           "apt-get install python3-coverage && python3 -m coverage run -m unittest discover --verbose --buffer"
 
       - name: Submit code coverage to Coveralls.io
+        if: github.event.pull_request.head.repo.fork == false
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         run: |
@@ -122,7 +123,6 @@ jobs:
           . venv/bin/activate
           pip install coveralls
           coveralls
-        continue-on-error: true
 
       - name: Login to registry
         if: github.event_name != 'pull_request'

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -118,11 +118,10 @@ jobs:
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         run: |
-          sudo apt-get install -y \
-            python3-setuptools
-          sudo python3 -m pip install \
-            coveralls
-          python3 -m coveralls
+          python3 -m venv venv
+          . venv/bin/activate
+          pip install coveralls
+          coveralls
         continue-on-error: true
 
       - name: Login to registry


### PR DESCRIPTION
It fails to uninstall rich when installing coveralls as that is now provided by Debian [1]

[1]: https://github.com/flathub-infra/flatpak-external-data-checker/actions/runs/26020883206/job/76481893282?pr=517#step:6:56