### PR TITLE
anityachecker: Propagate latest_version_created_on as timestamp

### DIFF
--- a/src/checkers/anityachecker.py
+++ b/src/checkers/anityachecker.py
@@ -1,4 +1,6 @@
 import logging
+import re
+from datetime import datetime, timezone
 
 from yarl import URL
 
@@ -14,6 +16,20 @@ from ..lib.utils import expand_version_constraints, filter_versions
 from . import Checker
 
 log = logging.getLogger(__name__)
+
+
+def _parse_timestamp(date_string: str | None) -> datetime | None:
+    # https://release-monitoring.org/api/v2/versions/?project_id=1
+    # latest_version_created_on: "2022-08-20T04:31:41.440163"
+    if date_string is None:
+        return None
+    try:
+        dt = datetime.fromisoformat(re.sub(r"Z$", "+00:00", date_string))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt
+    except ValueError as err:
+        raise CheckerQueryError("Failed to parse timestamp") from err
 
 
 class AnityaChecker(Checker):
@@ -79,22 +95,40 @@ class AnityaChecker(Checker):
         else:
             latest_version = result["latest_version"]
 
-        if isinstance(external_data, ExternalGitRepo):
-            return await self._check_git(external_data, latest_version)
-        assert isinstance(external_data, ExternalData)
-        return await self._check_data(external_data, latest_version)
+        latest_timestamp = _parse_timestamp(result.get("latest_version_created_on"))
 
-    async def _check_data(self, external_data: ExternalData, latest_version):
+        if isinstance(external_data, ExternalGitRepo):
+            return await self._check_git(
+                external_data, latest_version, latest_timestamp
+            )
+        assert isinstance(external_data, ExternalData)
+        return await self._check_data(external_data, latest_version, latest_timestamp)
+
+    async def _check_data(
+        self,
+        external_data: ExternalData,
+        latest_version: str,
+        latest_timestamp: datetime | None,
+    ):
         url_template = external_data.checker_data["url-template"]
         latest_url = self._substitute_template(
             url_template, self._version_parts(latest_version)
         )
 
         await self._update_version(
-            external_data, latest_version, latest_url, follow_redirects=False
+            external_data,
+            latest_version,
+            latest_url,
+            follow_redirects=False,
+            timestamp=latest_timestamp,
         )
 
-    async def _check_git(self, external_data: ExternalGitRepo, latest_version):
+    async def _check_git(
+        self,
+        external_data: ExternalGitRepo,
+        latest_version: str,
+        latest_timestamp: datetime | None,
+    ):
         tag_template = external_data.checker_data["tag-template"]
         latest_tag = self._substitute_template(
             tag_template, self._version_parts(latest_version)
@@ -106,7 +140,7 @@ class AnityaChecker(Checker):
             tag=latest_tag,
             branch=None,
             version=latest_version,
-            timestamp=None,
+            timestamp=latest_timestamp,
         ).fetch_remote()
 
         external_data.set_new_version(new_version)

--- a/tests/test_anityachecker.py
+++ b/tests/test_anityachecker.py
@@ -1,10 +1,11 @@
 import os
 import unittest
+from datetime import datetime, timezone
 from unittest import mock
 
 import aiohttp
 
-from src.checkers.anityachecker import AnityaChecker
+from src.checkers.anityachecker import AnityaChecker, _parse_timestamp
 from src.lib.checksums import MultiDigest
 from src.lib.errors import CheckerQueryError
 from src.lib.externaldata import (
@@ -56,6 +57,7 @@ class TestAnityaChecker(unittest.IsolatedAsyncioTestCase):
                         sha256="1f185aaef094123f8e25d8fa55661b3fd71020163a0174adb35a37685cda613b",
                     ),
                 )
+                self.assertIsNotNone(data.new_version.timestamp)
             elif data.filename == "boost_1_74_0.tar.bz2":
                 self.assertIsNotNone(data.new_version)
                 self.assertIsInstance(data.new_version, ExternalFile)
@@ -77,6 +79,7 @@ class TestAnityaChecker(unittest.IsolatedAsyncioTestCase):
                         sha256="83bfc1507731a0906e387fc28b7ef5417d591429e51e788417fe9ff025e116b1"
                     ),
                 )
+                self.assertIsNotNone(data.new_version.timestamp)
             elif data.filename == "flatpak-1.8.2.tar.xz":
                 self.assertIsNotNone(data.new_version)
                 self.assertIsInstance(data.new_version, ExternalFile)
@@ -98,6 +101,7 @@ class TestAnityaChecker(unittest.IsolatedAsyncioTestCase):
                         sha256="7926625df7c2282a5ee1a8b3c317af53d40a663b1bc6b18a2dc8747e265085b0"
                     ),
                 )
+                self.assertIsNotNone(data.new_version.timestamp)
             elif data.filename == "ostree.git":
                 self.assertIsNotNone(data.new_version)
                 self.assertIsInstance(data.new_version, ExternalGitRef)
@@ -114,6 +118,7 @@ class TestAnityaChecker(unittest.IsolatedAsyncioTestCase):
                 self.assertNotEqual(
                     data.new_version.commit, data.current_version.commit
                 )
+                self.assertIsNotNone(data.new_version.timestamp)
             elif data.filename == "gr-iqbal.git":
                 self.assertIsNone(data.new_version)
             elif data.filename == "yt-dlp.tar.gz":
@@ -134,22 +139,62 @@ class TestAnityaChecker(unittest.IsolatedAsyncioTestCase):
                 self.assertGreater(data.new_version.size, 0)
                 self.assertIsNotNone(data.new_version.checksum)
                 self.assertIsInstance(data.new_version.checksum, MultiDigest)
+                self.assertIsNotNone(data.new_version.timestamp)
             else:
                 self.fail(f"Unknown data {data.filename}")
 
 
+_FLATPAK_ANITYA_RESPONSE = {
+    "latest_version": "1.18.0",
+    "latest_version_created_on": "2026-06-08T18:54:44.176150",
+    "stable_versions": ["1.18.0", "1.16.0", "1.14.0", "1.12.0", "1.10.1", "1.8.2"],
+    "versions": ["1.18.0", "1.15.91", "1.16.0", "1.14.0", "1.12.0", "1.10.1", "1.8.2"],
+}
+
+_FAKE_ARCHIVE = ExternalFile(
+    url="https://example.invalid/fake-1.0.tar.xz",
+    checksum=MultiDigest(sha256="a" * 64),
+    size=1234,
+    version=None,
+    timestamp=None,
+)
+
+
 class TestAnityaCheckerMocked(unittest.IsolatedAsyncioTestCase):
+    @staticmethod
+    async def _fake_fetch(url, **kwargs):
+        return _FAKE_ARCHIVE._replace(url=str(url))
+
     def setUp(self):
         init_logging()
 
-        robots_patcher = mock.patch(
-            "src.lib.robots.RobotsCache.ensure_allowed", new_callable=mock.AsyncMock
-        )
-        robots_patcher.start()
-        self.addCleanup(robots_patcher.stop)
+        self.checker = AnityaChecker(session=mock.MagicMock())
 
-        self.checker = AnityaChecker.__new__(AnityaChecker)
-        self.checker.robots_cache = None
+        self.robots_patcher = mock.patch(
+            "src.lib.robots.RobotsCache.ensure_allowed",
+            new_callable=mock.AsyncMock,
+        )
+        self.robots_patcher.start()
+        self.addCleanup(self.robots_patcher.stop)
+
+        response_mock = mock.AsyncMock()
+        response_mock.json = mock.AsyncMock(return_value=_FLATPAK_ANITYA_RESPONSE)
+        cm = mock.AsyncMock()
+        cm.__aenter__ = mock.AsyncMock(return_value=response_mock)
+        cm.__aexit__ = mock.AsyncMock(return_value=False)
+        self.session_patcher = mock.patch(
+            "aiohttp.ClientSession.get",
+            return_value=cm,
+        )
+        self.session_patcher.start()
+        self.addCleanup(self.session_patcher.stop)
+
+        self.fetch_patcher = mock.patch(
+            "src.lib.utils.get_extra_data_info_from_url",
+            side_effect=self._fake_fetch,
+        )
+        self.fetch_patcher.start()
+        self.addCleanup(self.fetch_patcher.stop)
 
     def _make_external_data(self, checker_data):
         ed = mock.MagicMock(spec=ExternalData)
@@ -209,7 +254,7 @@ class TestAnityaCheckerMocked(unittest.IsolatedAsyncioTestCase):
         self.checker._check_data = mock.AsyncMock()
         await self.checker.check(ed)
 
-        self.checker._check_data.assert_awaited_once_with(ed, "3.0.0")
+        self.checker._check_data.assert_awaited_once_with(ed, "3.0.0", None)
 
     async def test_stable_only_selects_first_stable(self):
         payload = {
@@ -229,7 +274,7 @@ class TestAnityaCheckerMocked(unittest.IsolatedAsyncioTestCase):
         self.checker._check_data = mock.AsyncMock()
         await self.checker.check(ed)
 
-        self.checker._check_data.assert_awaited_once_with(ed, "2.0.0")
+        self.checker._check_data.assert_awaited_once_with(ed, "2.0.0", None)
 
     async def test_filter_no_match_raises(self):
 
@@ -270,7 +315,46 @@ class TestAnityaCheckerMocked(unittest.IsolatedAsyncioTestCase):
         self.checker._check_git = mock.AsyncMock()
         await self.checker.check(eg)
 
-        self.checker._check_git.assert_awaited_once_with(eg, "2023.1")
+        self.checker._check_git.assert_awaited_once_with(eg, "2023.1", None)
+
+    async def test_flatpak_timestamp(self):
+        checker = ManifestChecker(TEST_MANIFEST)
+        ext_data = await checker.check()
+
+        flatpak = next(d for d in ext_data if d.filename == "flatpak-1.8.2.tar.xz")
+
+        self.assertIsNotNone(flatpak.new_version)
+        self.assertIsInstance(flatpak.new_version, ExternalFile)
+
+        self.assertEqual(flatpak.new_version.version, "1.10.1")
+        self.assertEqual(
+            flatpak.new_version.url,
+            "https://github.com/flatpak/flatpak/releases/download/1.10.1/flatpak-1.10.1.tar.xz",
+        )
+
+        self.assertIsNotNone(flatpak.new_version.timestamp)
+        self.assertEqual(
+            flatpak.new_version.timestamp,
+            datetime(2026, 6, 8, 18, 54, 44, 176150, tzinfo=timezone.utc),
+        )
+
+
+class TestParseTimestamp(unittest.TestCase):
+    def test_invalid(self):
+        with self.assertRaises(CheckerQueryError):
+            _parse_timestamp("not-a-date")
+
+    def test_no_tz(self):
+        self.assertEqual(
+            _parse_timestamp("2026-06-08T18:54:44.176150"),
+            datetime(2026, 6, 8, 18, 54, 44, 176150, tzinfo=timezone.utc),
+        )
+
+    def test_z_suffix(self):
+        self.assertEqual(
+            _parse_timestamp("2022-07-15T10:00:00Z"),
+            datetime(2022, 7, 15, 10, 0, 0, tzinfo=timezone.utc),
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes: https://github.com/flathub-infra/flatpak-external-data-checker/issues/507